### PR TITLE
fix broken pyte.dis, test DebugStream

### DIFF
--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -399,7 +399,7 @@ class DebugStream(ByteStream):
             def __getattr__(self, event):
                 def inner(*args, **flags):
                     write(event.upper() + " ")
-                    write("; ".join(safestr(args)))
+                    write("; ".join(map(safestr, args)))
                     write(" ")
                     write(", ".join("{0}: {1}".format(name, safestr(arg))
                                     for name, arg in flags.iteritems()))

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -2,9 +2,12 @@
 
 from __future__ import unicode_literals
 
+from StringIO import StringIO
+
 import pytest
 
 from pyte import ctrl, esc
+from pyte.streams import DebugStream
 from . import TestStream, TestByteStream
 
 
@@ -190,3 +193,20 @@ def test_control_characters():
     assert handler.count == 1
     assert handler.args == (10, 10)
 
+def test_debug_stream():
+    # TODO doctest module docstrings instead
+    tests = [
+        (b'foo', '''DRAW f
+                    DRAW o
+                    DRAW o'''),
+        (b'\x1b[1;24r\x1b[4l\x1b[24;1H', '''SET_MARGINS 1; 24
+                                            RESET_MODE 4
+                                            CURSOR_POSITION 24; 1'''),
+    ]
+
+    for input, expected in tests:
+        output = StringIO()
+        stream = DebugStream(to=output)
+        stream.feed(input)
+        lines = [s.rstrip() for s in output.getvalue().split('\n') if s]
+        assert lines == [s.strip() for s in expected.split('\n')]


### PR DESCRIPTION
pyte.dis is currently broken:

```
$ python -m pyte foo
DRAW (; u; '; f; '; ,; )
DRAW (; u; '; o; '; ,; )
DRAW (; u; '; o; '; ,; )
```
