### PR TITLE
Fixed 'map' for Python3 compatibility (charset should be a real list, no...

### DIFF
--- a/pyte/charsets.py
+++ b/pyte/charsets.py
@@ -24,7 +24,7 @@ if sys.version_info[0] == 2:
 
 
 #: Latin1.
-LAT1_MAP = map(chr, range(256))
+LAT1_MAP = list(map(chr, range(256)))
 
 #: VT100 graphic character set.
 VT100_MAP = "".join(chr(c) for c in [


### PR DESCRIPTION
...t a map object or iterator.)
