### PR TITLE
make debugstream docstream example readable

### DIFF
--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -367,7 +367,7 @@ class ByteStream(Stream):
 
 
 class DebugStream(ByteStream):
-    """Stream, which dumps a subset of the dispatched events to a given
+    r"""Stream, which dumps a subset of the dispatched events to a given
     file-like object (:data:`sys.stdout` by default).
 
     >>> stream = DebugStream()


### PR DESCRIPTION
I had trouble with the Sphinx docs example http://pyte.readthedocs.org/en/latest/api.html#pyte.streams.DebugStream at first because of this.
