### PR TITLE
checking for basestring makes more flexible

### DIFF
--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -140,8 +140,9 @@ class Stream(object):
 
         :param str char: a character to consume.
         """
-        if not isinstance(char, str):
+        if not isinstance(char, basestring):
             raise TypeError("%s requires str input" % self.__class__.__name__)
+        char = str(char)
 
         try:
             self.handlers.get(self.state)(char)
@@ -161,8 +162,9 @@ class Stream(object):
 
         :param str chars: a string to feed from.
         """
-        if not isinstance(chars, str):
+        if not isinstance(chars, basestring):
             raise TypeError("%s requires str input" % self.__class__.__name__)
+        chars = str(chars)
 
         for char in chars: self.consume(char)
 


### PR DESCRIPTION
In Python2 it's sadly possible to have a string which is not of exactly type `str`, e.g., `unicode` strings. For the `isinstance()` checks it doesn't matter which type of string it is, as long as it is one kind of them. To check for all kinds of strings, it is better to check for `basestring`, because that works for all string types.
