### PR TITLE
Handle (but ignore) ESC % <C> sequences for switching to/from UTF-8.

### DIFF
--- a/pyte/escape.py
+++ b/pyte/escape.py
@@ -3,7 +3,7 @@
     pyte.escape
     ~~~~~~~~~~~
 
-    This module defines bot CSI and non-CSI escape sequences, recognized
+    This module defines both CSI and non-CSI escape sequences, recognized
     by :class:`~pyte.streams.Stream` and subclasses.
 
     :copyright: (c) 2011-2013 by Selectel, see AUTHORS for details.
@@ -39,6 +39,19 @@ DECSC = "7"
 #: attribute (graphic rendition), character set, and origin mode
 #: selection. If none were saved, move cursor to home position.
 DECRC = "8"
+
+
+# "Percent" escape sequences.
+# ---------------------------
+
+#: *Select default (ISO 646 / ISO 8859-1)*.
+DEFAULT = "@"
+
+#: *Select UTF-8*.
+UTF8 = "G"
+
+#: *Select UTF-8 (obsolete)*.
+UTF8_OBSOLETE = "8"
 
 
 # "Sharp" escape sequences.

--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -54,7 +54,7 @@ class Stream(object):
 
         `man console_codes <http://linux.die.net/man/4/console_codes>`_
             For details on console codes listed bellow in :attr:`basic`,
-            :attr:`escape`, :attr:`csi` and :attr:`sharp`.
+            :attr:`escape`, :attr:`csi`, :attr:`sharp` and :attr:`percent`.
     """
 
     #: Control sequences, which don't require any arguments.
@@ -84,6 +84,14 @@ class Stream(object):
     #: "sharp" escape sequences -- ``ESC # <N>``.
     sharp = {
         esc.DECALN: "alignment_display",
+    }
+
+    #: "percent" escape sequences (Linux sequence to select character
+    #  set) -- ``ESC % <C>``.
+    percent = {
+        esc.DEFAULT: "charset_default",
+        esc.UTF8: "charset_utf8",
+        esc.UTF8_OBSOLETE: "charset_utf8",
     }
 
     #: CSI escape sequences -- ``CSI P1;P2;...;Pn <fn>``.
@@ -121,6 +129,7 @@ class Stream(object):
             "escape": self._escape,
             "arguments": self._arguments,
             "sharp": self._sharp,
+            "percent": self._percent,
             "charset": self._charset
         }
 
@@ -243,10 +252,13 @@ class Stream(object):
         Most non-VT52 commands start with a left-bracket after the
         escape and then a stream of parameters and a command; with
         a single notable exception -- :data:`escape.DECOM` sequence,
-        which starts with a sharp.
+        which starts with a sharp. [FIXME: I don't know how to
+        update this comment to account for the percent.]
         """
         if char == "#":
             self.state = "sharp"
+        elif char == "%":
+            self.state = "percent"
         elif char == "[":
             self.state = "arguments"
         elif char in "()":
@@ -258,6 +270,10 @@ class Stream(object):
     def _sharp(self, char):
         """Parse arguments of a `"#"` seqence."""
         self.dispatch(self.sharp[char])
+
+    def _percent(self, char):
+        """Parse arguments of a `"%"` seqence."""
+        self.dispatch(self.percent[char])
 
     def _charset(self, char):
         """Parse ``G0`` or ``G1`` charset code."""


### PR DESCRIPTION
This commit adds handling in the Stream class for Linux escape
sequences used to select either UTF-8 or default character sets.

Currently the commands generated when these sequences are detected are
ignored, but it might make sense in the future to have ByteStream use
these sequences to switch encodings.

(I want to handle Linux serial console output and just want the ESC % G sequences to be ignored, I'm already taking care of decoding myself.  Please note the "FIXME" in the comment where I'm not sure what to say.)