### PR TITLE
Add BEL as terminator for OSC and remove ST from special symbols

### DIFF
--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -129,7 +129,7 @@ class Stream(object):
 
     #: A regular expression pattern matching everything what can be
     #: considered plain text.
-    _special = set([ctrl.ESC, ctrl.CSI, ctrl.NUL, ctrl.DEL, ctrl.OSC, ctrl.ST])
+    _special = set([ctrl.ESC, ctrl.CSI, ctrl.NUL, ctrl.DEL, ctrl.OSC])
     _special.update(basic)
     _text_pattern = re.compile(
         b"[^" + b"".join(map(re.escape, _special)) + b"]+")
@@ -332,7 +332,7 @@ class Stream(object):
                 param = bytearray()
                 while True:
                     char = yield
-                    if char == ST:
+                    if char == ST or char == ctrl.BEL:
                         break
                     else:
                         param.extend(char)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -194,6 +194,14 @@ def test_set_title_icon_name():
     stream.feed(ctrl.OSC + b"0;bar" + ctrl.ST)
     assert screen.title == screen.icon_name == "bar"
 
+    # d) set both icon name and title then terminate with BEL
+    stream.feed(ctrl.OSC + b"0;bar" + ctrl.BEL)
+    assert screen.title == screen.icon_name == "bar"
+
+    # e) test ➜ ('\xe2\x9e\x9c') symbol, that contains string terminator \x9c
+    stream.feed(u"➜".encode("utf-8"))
+    assert screen.buffer[0][0].data == u"➜"
+
 
 def test_compatibility_api():
     screen = Screen(80, 24)


### PR DESCRIPTION
Hello, 

This commit contains two fixes:
1) Add BEL as terminator for OSC according to http://man7.org/linux/man-pages/man4/console_codes.4.html:
> In  addition to the ECMA-48 string terminator (ST), xterm(1) accepts a BEL to terminate an OSC string.
2) ST - string terminator shouldn't be a special symbol.