### PR TITLE
Moved decoding back to ``pyte.streams.Stream``

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -16,14 +16,12 @@ This release is NOT backward compatible with 0.5.X branch!
 - Restricted ``Stream`` to a single listener and deprecated ``attach`` and
   ``detach``. The old logic can be emulated by a fanout proxy, forwarding
   events to a list of its listeners.
-- Merged ``Stream`` and ``ByteStream`` and required bytes as input.
-  This allows to decode the bytes on the ``Screen`` side. The next version
-  will force the use of ``bytes``. See issue #49 on GitHub.
 - Removed overly generic ``Screen.__before__`` and ``Screen.__after__``.
 - Renamed ``Screen.set_charset`` to a more appropriate
   ``Screen.define_charset``.
-- Added support for ECMA-035 `DOCS` command, which the Linux terminal uses
-  to enable UTF-8.
+- Added support for ECMA-035 `DOCS` command to ``ByteStream`` which no longer
+  accepts ``encoding`` as an argument and instead sets it as instructed by
+  `DOCS`. The default encoding is assumed to be UTF-8.
 - Added support for OSC sequences allowing to set terminal title and
   icon name.
 - Allowed 256 and 24bit colours in ``Screen.select_graphic_rendition``.

--- a/examples/helloworld.py
+++ b/examples/helloworld.py
@@ -17,7 +17,7 @@ import pyte
 if __name__ == "__main__":
     screen = pyte.Screen(80, 24)
     stream = pyte.Stream(screen)
-    stream.feed(b"Hello World!")
+    stream.feed("Hello World!")
 
     for idx, line in enumerate(screen.display, 1):
         print("{0:2d} {1} ¶".format(idx, line))

--- a/examples/history.py
+++ b/examples/history.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
 
     pages = 3
     stream.feed(os.linesep.join(random_string(screen.columns)
-                                for _ in range(screen.lines * pages)).encode())
+                                for _ in range(screen.lines * pages)))
     screen.prev_page()
 
     print_screen(screen, "Hit ENTER to move up!")

--- a/examples/webterm.py
+++ b/examples/webterm.py
@@ -29,7 +29,7 @@ import pyte
 class Terminal:
     def __init__(self, columns, lines):
         self.screen = pyte.DiffScreen(columns, lines)
-        self.stream = pyte.Stream()
+        self.stream = pyte.ByteStream()
         self.stream.attach(self.screen)
 
     def feed(self, data):

--- a/pyte/charsets.py
+++ b/pyte/charsets.py
@@ -136,8 +136,8 @@ VAX42_MAP = "".join(chr(c) for c in [
 
 
 MAPS = {
-    b"B": LAT1_MAP,
-    b"0": VT100_MAP,
-    b"U": IBMPC_MAP,
-    b"V": VAX42_MAP
+    "B": LAT1_MAP,
+    "0": VT100_MAP,
+    "U": IBMPC_MAP,
+    "V": VAX42_MAP
 }

--- a/pyte/compat.py
+++ b/pyte/compat.py
@@ -18,9 +18,5 @@ if sys.version_info[0] == 2:
     range = xrange
     str = unicode
     chr = unichr
-
-    from functools import partial
-    iter_bytes = partial(map, ord)
 else:
     from builtins import map, range, str, chr
-    iter_bytes = iter

--- a/pyte/control.py
+++ b/pyte/control.py
@@ -14,57 +14,57 @@
 """
 
 #: *Space*: Not suprisingly -- ``" "``.
-SP = b" "
+SP = " "
 
 #: *Null*: Does nothing.
-NUL = b"\x00"
+NUL = "\x00"
 
 #: *Bell*: Beeps.
-BEL = b"\x07"
+BEL = "\x07"
 
 #: *Backspace*: Backspace one column, but not past the begining of the
 #: line.
-BS = b"\x08"
+BS = "\x08"
 
 #: *Horizontal tab*: Move cursor to the next tab stop, or to the end
 #: of the line if there is no earlier tab stop.
-HT = b"\x09"
+HT = "\x09"
 
 #: *Linefeed*: Give a line feed, and, if :data:`pyte.modes.LNM` (new
 #: line mode) is set also a carriage return.
-LF = b"\n"
+LF = "\n"
 #: *Vertical tab*: Same as :data:`LF`.
-VT = b"\x0b"
+VT = "\x0b"
 #: *Form feed*: Same as :data:`LF`.
-FF = b"\x0c"
+FF = "\x0c"
 
 #: *Carriage return*: Move cursor to left margin on current line.
-CR = b"\r"
+CR = "\r"
 
 #: *Shift out*: Activate G1 character set.
-SO = b"\x0e"
+SO = "\x0e"
 
 #: *Shift in*: Activate G0 character set.
-SI = b"\x0f"
+SI = "\x0f"
 
 #: *Cancel*: Interrupt escape sequence. If received during an escape or
 #: control sequence, cancels the sequence and displays substitution
 #: character.
-CAN = b"\x18"
+CAN = "\x18"
 #: *Substitute*: Same as :data:`CAN`.
-SUB = b"\x1a"
+SUB = "\x1a"
 
 #: *Escape*: Starts an escape sequence.
-ESC = b"\x1b"
+ESC = "\x1b"
 
 #: *Delete*: Is ignored.
-DEL = b"\x7f"
+DEL = "\x7f"
 
 #: *Control sequence introducer*: An equivalent for ``ESC [``.
-CSI = b"\x9b"
+CSI = "\x9b"
 
 #: *String terminator*.
-ST = b"\x9c"
+ST = "\x9c"
 
 #: *Operating system command*.
-OSC = b"\x9d"
+OSC = "\x9d"

--- a/pyte/escape.py
+++ b/pyte/escape.py
@@ -13,141 +13,141 @@
 """
 
 #: *Reset*.
-RIS = b"c"
+RIS = "c"
 
 #: *Index*: Move cursor down one line in same column. If the cursor is
 #: at the bottom margin, the screen performs a scroll-up.
-IND = b"D"
+IND = "D"
 
 #: *Next line*: Same as :data:`pyte.control.LF`.
-NEL = b"E"
+NEL = "E"
 
 #: Tabulation set: Set a horizontal tab stop at cursor position.
-HTS = b"H"
+HTS = "H"
 
 #: *Reverse index*: Move cursor up one line in same column. If the
 #: cursor is at the top margin, the screen performs a scroll-down.
-RI = b"M"
+RI = "M"
 
 #: Save cursor: Save cursor position, character attribute (graphic
 #: rendition), character set, and origin mode selection (see
 #: :data:`DECRC`).
-DECSC = b"7"
+DECSC = "7"
 
 #: *Restore cursor*: Restore previously saved cursor position, character
 #: attribute (graphic rendition), character set, and origin mode
 #: selection. If none were saved, move cursor to home position.
-DECRC = b"8"
+DECRC = "8"
 
 # "Sharp" escape sequences.
 # -------------------------
 
 #: *Alignment display*: Fill screen with uppercase E's for testing
 #: screen focus and alignment.
-DECALN = b"8"
+DECALN = "8"
 
 
 # ECMA-48 CSI sequences.
 # ---------------------
 
 #: *Insert character*: Insert the indicated # of blank characters.
-ICH = b"@"
+ICH = "@"
 
 #: *Cursor up*: Move cursor up the indicated # of lines in same column.
 #: Cursor stops at top margin.
-CUU = b"A"
+CUU = "A"
 
 #: *Cursor down*: Move cursor down the indicated # of lines in same
 #: column. Cursor stops at bottom margin.
-CUD = b"B"
+CUD = "B"
 
 #: *Cursor forward*: Move cursor right the indicated # of columns.
 #: Cursor stops at right margin.
-CUF = b"C"
+CUF = "C"
 
 #: *Cursor back*: Move cursor left the indicated # of columns. Cursor
 #: stops at left margin.
-CUB = b"D"
+CUB = "D"
 
 #: *Cursor next line*: Move cursor down the indicated # of lines to
 #: column 1.
-CNL = b"E"
+CNL = "E"
 
 #: *Cursor previous line*: Move cursor up the indicated # of lines to
 #: column 1.
-CPL = b"F"
+CPL = "F"
 
 #: *Cursor horizontal align*: Move cursor to the indicated column in
 #: current line.
-CHA = b"G"
+CHA = "G"
 
 #: *Cursor position*: Move cursor to the indicated line, column (origin
 #: at ``1, 1``).
-CUP = b"H"
+CUP = "H"
 
 #: *Erase data* (default: from cursor to end of line).
-ED = b"J"
+ED = "J"
 
 #: *Erase in line* (default: from cursor to end of line).
-EL = b"K"
+EL = "K"
 
 #: *Insert line*: Insert the indicated # of blank lines, starting from
 #: the current line. Lines displayed below cursor move down. Lines moved
 #: past the bottom margin are lost.
-IL = b"L"
+IL = "L"
 
 #: *Delete line*: Delete the indicated # of lines, starting from the
 #: current line. As lines are deleted, lines displayed below cursor
 #: move up. Lines added to bottom of screen have spaces with same
 #: character attributes as last line move up.
-DL = b"M"
+DL = "M"
 
 #: *Delete character*: Delete the indicated # of characters on the
 #: current line. When character is deleted, all characters to the right
 #: of cursor move left.
-DCH = b"P"
+DCH = "P"
 
 #: *Erase character*: Erase the indicated # of characters on the
 #: current line.
-ECH = b"X"
+ECH = "X"
 
 #: *Horizontal position relative*: Same as :data:`CUF`.
-HPR = b"a"
+HPR = "a"
 
 #: *Device Attributes*.
-DA = b"c"
+DA = "c"
 
 #: *Vertical position adjust*: Move cursor to the indicated line,
 #: current column.
-VPA = b"d"
+VPA = "d"
 
 #: *Vertical position relative*: Same as :data:`CUD`.
-VPR = b"e"
+VPR = "e"
 
 #: *Horizontal / Vertical position*: Same as :data:`CUP`.
-HVP = b"f"
+HVP = "f"
 
 #: *Tabulation clear*: Clears a horizontal tab stop at cursor position.
-TBC = b"g"
+TBC = "g"
 
 #: *Set mode*.
-SM = b"h"
+SM = "h"
 
 #: *Reset mode*.
-RM = b"l"
+RM = "l"
 
 #: *Select graphics rendition*: The terminal can display the following
 #: character attributes that change the character display without
 #: changing the character (see :mod:`pyte.graphics`).
-SGR = b"m"
+SGR = "m"
 
 #: *Device status report*.
-DSR = b"n"
+DSR = "n"
 
 #: *Select top and bottom margins*: Selects margins, defining the
 #: scrolling region; parameters are top and bottom line. If called
 #: without any arguments, whole screen is used.
-DECSTBM = b"r"
+DECSTBM = "r"
 
 #: *Horizontal position adjust*: Same as :data:`CHA`.
-HPA = b"'"
+HPA = "'"

--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -10,7 +10,7 @@
     >>> import pyte
     >>> screen = pyte.Screen(80, 24)
     >>> stream = pyte.Stream(screen)
-    >>> stream.feed(b"\x1b[5B")  # Move the cursor down 5 rows.
+    >>> stream.feed("\x1b[5B")  # Move the cursor down 5 rows.
     >>> screen.cursor.y
     5
 

--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -218,9 +218,7 @@ class Stream(object):
         will be the bottleneck, because it processes just one character
         at a time.
 
-        We did many manual optimizations to this function in order to make
-        it as efficient as possible. Don't change anything without profiling
-        first.
+        Don't change anything without profiling first.
         """
         basic = self.basic
         listener = self.listener
@@ -248,7 +246,7 @@ class Stream(object):
         while True:
             # ``True`` tells ``Screen.feed`` that it is allowed to send
             # chunks of plain text directly to the listener, instead
-            # of this generator.)
+            # of this generator.
             char = yield True
 
             if char == ESC:

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -37,8 +37,8 @@ def test_mark_single_line():
 
     # a) draw().
     screen.dirty.clear()
-    screen.draw(b"f")
-    assert len(screen.dirty) is 1
+    screen.draw("f")
+    assert len(screen.dirty) == 1
     assert screen.cursor.y in screen.dirty
 
     # b) rest ...
@@ -46,7 +46,7 @@ def test_mark_single_line():
                    "erase_characters", "erase_in_line"]:
         screen.dirty.clear()
         getattr(screen, method)()
-        assert len(screen.dirty) is 1
+        assert len(screen.dirty) == 1
         assert screen.cursor.y in screen.dirty
 
 
@@ -128,12 +128,12 @@ def test_draw_wrap():
 
     # fill every character cell on the first row
     for _ in range(80):
-        screen.draw(b"g")
+        screen.draw("g")
     assert screen.cursor.y == 0
     screen.dirty.clear()
 
     # now write one more character which should cause wrapping
-    screen.draw(b"h")
+    screen.draw("h")
     assert screen.cursor.y == 1
     # regression test issue #36 where the wrong line was marked as
     # dirty

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -20,7 +20,7 @@ def test_index():
     # Filling the screen with line numbers, so it's easier to
     # track history contents.
     for idx in range(len(screen.buffer)):
-        screen.draw(str(idx).encode("utf-8"))
+        screen.draw(str(idx))
         if idx != len(screen.buffer) - 1:
             screen.linefeed()
 
@@ -52,7 +52,7 @@ def test_reverse_index():
     # Filling the screen with line numbers, so it's easier to
     # track history contents.
     for idx in range(len(screen.buffer)):
-        screen.draw(str(idx).encode("utf-8"))
+        screen.draw(str(idx))
         if idx != len(screen.buffer) - 1:
             screen.linefeed()
 
@@ -89,7 +89,7 @@ def test_prev_page():
     # Once again filling the screen with line numbers, but this time,
     # we need them to span on multiple lines.
     for idx in range(len(screen.buffer) * 10):
-        screen.draw(str(idx).encode("utf-8"))
+        screen.draw(str(idx))
 
         screen.linefeed()
 
@@ -159,7 +159,7 @@ def test_prev_page():
     screen.set_mode(mo.LNM)
 
     for idx in range(len(screen.buffer) * 10):
-        screen.draw(str(idx).encode("utf-8"))
+        screen.draw(str(idx))
 
         screen.linefeed()
 
@@ -197,7 +197,7 @@ def test_prev_page():
     screen.set_mode(mo.LNM)
 
     for idx in range(len(screen.buffer) * 10):
-        screen.draw(str(idx).encode("utf-8"))
+        screen.draw(str(idx))
 
         screen.linefeed()
 
@@ -245,7 +245,7 @@ def test_prev_page():
     screen.set_mode(mo.LNM)
 
     for idx in range(len(screen.buffer) * 10):
-        screen.draw(str(idx).encode("utf-8"))
+        screen.draw(str(idx))
 
         screen.linefeed()
 
@@ -296,7 +296,7 @@ def test_next_page():
     # Once again filling the screen with line numbers, but this time,
     # we need them to span on multiple lines.
     for idx in range(len(screen.buffer) * 5):
-        screen.draw(str(idx).encode("utf-8"))
+        screen.draw(str(idx))
 
         screen.linefeed()
 
@@ -367,13 +367,13 @@ def test_ensure_width(monkeypatch):
     screen = HistoryScreen(5, 5, history=50)
     screen.set_mode(mo.LNM)
     escape = dict(Stream.escape)
-    escape.update({b"N": "next_page", b"P": "prev_page"})
+    escape.update({"N": "next_page", "P": "prev_page"})
     monkeypatch.setattr(Stream, "escape", escape)
 
     stream = Stream(screen)
 
     for idx in range(len(screen.buffer) * 5):
-        stream.feed((str(idx) + os.linesep).encode("utf-8"))
+        stream.feed(str(idx) + os.linesep)
 
     assert screen.display == [
         "21   ",
@@ -386,7 +386,7 @@ def test_ensure_width(monkeypatch):
     # a) shrinking the screen, expecting the lines displayed to
     #    be truncated.
     screen.resize(5, 2)
-    stream.feed(ctrl.ESC + b"P")
+    stream.feed(ctrl.ESC + "P")
 
     assert all(len(l) != 2 for l in screen.history.top)
     assert all(len(l) == 2 for l in screen.history.bottom)
@@ -401,7 +401,7 @@ def test_ensure_width(monkeypatch):
     # b) expading the screen, expecting the lines displayed to
     #    be filled with whitespace characters.
     screen.resize(5, 10)
-    stream.feed(ctrl.ESC + b"N")
+    stream.feed(ctrl.ESC + "N")
 
     assert all(len(l) == 10 for l in list(screen.history.top)[-3:])
     assert all(len(l) != 10 for l in screen.history.bottom)
@@ -419,7 +419,7 @@ def test_not_enough_lines():
     screen.set_mode(mo.LNM)
 
     for idx in range(len(screen.buffer)):
-        screen.draw(str(idx).encode("utf-8"))
+        screen.draw(str(idx))
 
         screen.linefeed()
 
@@ -462,12 +462,12 @@ def test_draw(monkeypatch):
     screen = HistoryScreen(5, 5, history=50)
     screen.set_mode(mo.LNM)
     escape = dict(Stream.escape)
-    escape.update({b"N": "next_page", b"P": "prev_page"})
+    escape.update({"N": "next_page", "P": "prev_page"})
     monkeypatch.setattr(Stream, "escape", escape)
 
     stream = Stream(screen)
     for idx in range(len(screen.buffer) * 5):
-        stream.feed((str(idx) + os.linesep).encode("utf-8"))
+        stream.feed(str(idx) + os.linesep)
 
     assert screen.display == [
         "21   ",
@@ -479,10 +479,10 @@ def test_draw(monkeypatch):
 
     # a) doing a pageup and then a draw -- expecting the screen
     #    to scroll to the bottom before drawing anything.
-    stream.feed(ctrl.ESC + b"P")
-    stream.feed(ctrl.ESC + b"P")
-    stream.feed(ctrl.ESC + b"N")
-    stream.feed(b"x")
+    stream.feed(ctrl.ESC + "P")
+    stream.feed(ctrl.ESC + "P")
+    stream.feed(ctrl.ESC + "N")
+    stream.feed("x")
 
     assert screen.display == [
         "21   ",
@@ -496,20 +496,20 @@ def test_draw(monkeypatch):
 def test_cursor_is_hidden(monkeypatch):
     screen = HistoryScreen(5, 5, history=50)
     escape = dict(Stream.escape)
-    escape.update({b"N": "next_page", b"P": "prev_page"})
+    escape.update({"N": "next_page", "P": "prev_page"})
     monkeypatch.setattr(Stream, "escape", escape)
 
     stream = Stream(screen)
     for idx in range(len(screen.buffer) * 5):
-        stream.feed((str(idx) + os.linesep).encode("utf-8"))
+        stream.feed(str(idx) + os.linesep)
 
     assert not screen.cursor.hidden
 
-    stream.feed(ctrl.ESC + b"P")
+    stream.feed(ctrl.ESC + "P")
     assert screen.cursor.hidden
-    stream.feed(ctrl.ESC + b"P")
+    stream.feed(ctrl.ESC + "P")
     assert screen.cursor.hidden
-    stream.feed(ctrl.ESC + b"N")
+    stream.feed(ctrl.ESC + "N")
     assert screen.cursor.hidden
-    stream.feed(ctrl.ESC + b"N")
+    stream.feed(ctrl.ESC + "N")
     assert not screen.cursor.hidden

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -25,6 +25,6 @@ def test_input_output(name):
         output = json.load(handle)
 
     screen = pyte.Screen(80, 24)
-    stream = pyte.Stream(screen)
+    stream = pyte.ByteStream(screen)
     stream.feed(input)
     assert screen.display == output

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -270,6 +270,14 @@ def test_draw():
     assert screen.display == ["yxa", "   ", "   "]
 
 
+def test_draw_russian():
+    # Test from https://github.com/selectel/pyte/issues/65
+    screen = Screen(20, 1)
+    stream = Stream(screen)
+    stream.feed("Нерусский текст")
+    assert screen.display == ["Нерусский текст     "]
+
+
 def test_draw_multiple_chars():
     screen = Screen(10, 1)
     screen.draw("foobar")
@@ -277,12 +285,11 @@ def test_draw_multiple_chars():
     assert screen.display == ["foobar    "]
 
 
-@pytest.mark.xfail
 def test_draw_utf8():
     # See https://github.com/selectel/pyte/issues/62
     screen = Screen(1, 1)
-    stream = Stream(screen)
-    stream.feed("\xE2\x80\x9D")
+    stream = ByteStream(screen)
+    stream.feed(b"\xE2\x80\x9D")
     assert screen.display == ["”"]
 
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -221,21 +221,10 @@ def test_compatibility_api():
     stream.detach(screen)
 
 
-def test_draw_russian():
-    # Test from https://github.com/selectel/pyte/issues/65
-    screen = Screen(20, 1)
-    screen.draw = handler = argcheck()
-
-    stream = Stream(screen)
-    stream.feed("Нерусский текст")
-    assert handler.count == 1
-    assert handler.args == ("Нерусский текст", )
-
-
 def test_debug_stream():
     tests = [
-        ("foo", "DRAW foo"),
-        ("\x1b[1;24r\x1b[4l\x1b[24;1H",
+        (b"foo", "DRAW foo"),
+        (b"\x1b[1;24r\x1b[4l\x1b[24;1H",
          "SET_MARGINS 1; 24\nRESET_MODE 4\nCURSOR_POSITION 24; 1"),
     ]
 
@@ -246,6 +235,16 @@ def test_debug_stream():
 
         lines = [l.rstrip() for l in output.getvalue().splitlines()]
         assert lines == expected.splitlines()
+
+
+def test_byte_stream_feed():
+    screen = Screen(20, 1)
+    screen.draw = handler = argcheck()
+
+    stream = ByteStream(screen)
+    stream.feed("Нерусский текст".encode("utf-8"))
+    assert handler.count == 1
+    assert handler.args == ("Нерусский текст", )
 
 
 def test_byte_stream_select_other_charset():


### PR DESCRIPTION
This PR moves the decoding back to ``pyte.streams.Stream`` and resurrects ``pyte.streams.ByteStream`` which, however, no longer accepts ``encoding`` as parameter but instead assumes UTF-8 by default and switches to alternative encoding on the DOCS command.

Making the stream byte-only (see febdad70ba4b0eec509e1cf10d9ed2d9fb284e85) was a bad idea, because in the UTF-8 mode the terminal [must](http://www.cl.cam.ac.uk/~mgk25/unicode.html#term) decode the input **before** processing any escape sequences, otherwise parts of the encoded Unicode characters can trigger spurious commands, as reported in #62 and #65.