### PR TITLE
Fix benchmark perf 0.8+ compatibility

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,8 +1,8 @@
-import os
 import os.path
+import sys
 from functools import partial
 
-from perf.text_runner import TextRunner
+from perf import Runner
 
 from pyte import Screen, Stream
 
@@ -18,6 +18,7 @@ def make_benchmark(path):
 if __name__ == "__main__":
     benchmark_dir = os.path.dirname(__file__)
     benchmark = os.path.join(benchmark_dir, os.environ["BENCHMARK"])
+    sys.argv += ("--inherit-environ", "BENCHMARK")
 
-    runner = TextRunner()
-    runner.bench_func(make_benchmark(benchmark))
+    runner = Runner()
+    runner.bench_func("MAIN_BENCHMARK", make_benchmark(benchmark))

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,2 @@
+pytest
+perf >= 0.8.0


### PR DESCRIPTION
Add requirements_dev.txt for develop-only requirements

Fix compatibility with perf 0.8+

> Version 0.8.0 (2016-10-14)
> A benchmark must now have a name: all runs must have a name metadata.
> Remove name argument from Runner constructor and add name parameter to Benchmark.bench_func() and Benchmark.bench_sample_func()
> perf.text_runner.TextRunner becomes simply perf.Runner. Remove the perf.text_runner module.

> Version 0.7.8 (2016-09-10)
> Worker child processes are now run in a fresh environment: environment variables are removed, to enhance reproductability.
> Add --inherit-environ command line argument.