### PR TITLE
Fix non-7bit strings in Python2.X

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -15,6 +15,7 @@
     :license: LGPL, see LICENSE for more details.
 """
 
+import io
 import os.path
 import sys
 from functools import partial
@@ -28,8 +29,8 @@ from pyte import Screen, Stream
 
 
 def make_benchmark(path):
-    with open(path, "rt") as handle:
-        data = handle.read().decode('utf8')
+    with io.open(path, "rt", encoding="utf-8") as handle:
+        data = handle.read()
 
     stream = Stream(Screen(80, 24))
     return partial(stream.feed, data)

--- a/benchmark.py
+++ b/benchmark.py
@@ -29,7 +29,7 @@ from pyte import Screen, Stream
 
 def make_benchmark(path):
     with open(path, "rt") as handle:
-        data = handle.read()
+        data = handle.read().decode('utf8')
 
     stream = Stream(Screen(80, 24))
     return partial(stream.feed, data)

--- a/pyte/__main__.py
+++ b/pyte/__main__.py
@@ -30,4 +30,4 @@ if __name__ == "__main__":
     if len(sys.argv) == 1:
         pyte.dis(sys.stdin.read())
     else:
-        pyte.dis("".join(sys.argv[1:]))
+        pyte.dis(u"".join(sys.argv[1:]))

--- a/pyte/control.py
+++ b/pyte/control.py
@@ -12,6 +12,7 @@
                     see AUTHORS for details.
     :license: LGPL, see LICENSE for more details.
 """
+from __future__ import unicode_literals
 
 #: *Space*: Not suprisingly -- ``" "``.
 SP = " "
@@ -58,13 +59,13 @@ SUB = "\x1a"
 ESC = "\x1b"
 
 #: *Delete*: Is ignored.
-DEL = u"\x7f"
+DEL = "\x7f"
 
 #: *Control sequence introducer*: An equivalent for ``ESC [``.
-CSI = u"\x9b"
+CSI = "\x9b"
 
 #: *String terminator*.
-ST = u"\x9c"
+ST = "\x9c"
 
 #: *Operating system command*.
-OSC = u"\x9d"
+OSC = "\x9d"

--- a/pyte/control.py
+++ b/pyte/control.py
@@ -58,13 +58,13 @@ SUB = "\x1a"
 ESC = "\x1b"
 
 #: *Delete*: Is ignored.
-DEL = "\x7f"
+DEL = u"\x7f"
 
 #: *Control sequence introducer*: An equivalent for ``ESC [``.
-CSI = "\x9b"
+CSI = u"\x9b"
 
 #: *String terminator*.
-ST = "\x9c"
+ST = u"\x9c"
 
 #: *Operating system command*.
-OSC = "\x9d"
+OSC = u"\x9d"

--- a/pyte/escape.py
+++ b/pyte/escape.py
@@ -11,6 +11,7 @@
                     see AUTHORS for details.
     :license: LGPL, see LICENSE for more details.
 """
+from __future__ import unicode_literals
 
 #: *Reset*.
 RIS = "c"

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -46,7 +46,7 @@ from . import (
     graphics as g,
     modes as mo
 )
-from .compat import map, range
+from .compat import map, range, str
 from .streams import Stream
 
 
@@ -1294,7 +1294,7 @@ class DebugScreen(object):
     def only_wrapper(self, attr):
         def wrapper(*args, **kwargs):
             self.to.write(str(DebugEvent(attr, args, kwargs)))
-            self.to.write(os.linesep)
+            self.to.write(str(os.linesep))
 
         return wrapper
 


### PR DESCRIPTION
There is a problem with 8bit control sequences, which lead to exceptions like

> ascii' codec can't encode character u'\x9d' in position 0: ordinal not in range(128)

I changed them to unicode strings.

Update: same problem with file input in benchmark. I think we should add some tests on this.