### PR TITLE
Fixes to history and page up/down logic

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Contributors
 - Dmitriy Novozhilov
 - Sergey Zavgorodniy
 - Byron Roosa
+- Andrew Crozier

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,9 @@ Here you can see the full list of changes between each pyte release.
 Version 0.8.0-dev
 -------------
 
+- Modify logic around tracking position in the ``HistoryScreen``, allowing the
+  full history to be access. See PR #96 on GitHub.
+
 Version 0.7.0
 -------------
 

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -1160,7 +1160,7 @@ class HistoryScreen(Screen):
         # If we're at the bottom of the history buffer and `DECTCEM`
         # mode is set -- show the cursor.
         self.cursor.hidden = not (
-            abs(self.history.position - self.history.size) < self.lines and
+            self.history.position == self.history.size and
             mo.DECTCEM in self.mode
         )
 

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -1111,7 +1111,7 @@ class HistoryScreen(Screen):
     _wrapped.update(["next_page", "prev_page"])
 
     def __init__(self, columns, lines, history=100, ratio=.5):
-        self.history = History(deque(maxlen=history // 2),
+        self.history = History(deque(maxlen=history),
                                deque(maxlen=history),
                                float(ratio),
                                history,

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -1216,7 +1216,7 @@ class HistoryScreen(Screen):
                 self.buffer[y]
                 for y in range(self.lines - 1, self.lines - mid - 1, -1))
             self.history = self.history \
-                ._replace(position=self.history.position - self.lines)
+                ._replace(position=self.history.position - mid)
 
             for y in range(self.lines - 1, mid - 1, -1):
                 self.buffer[y] = self.buffer[y - mid]
@@ -1233,7 +1233,7 @@ class HistoryScreen(Screen):
 
             self.history.top.extend(self.buffer[y] for y in range(mid))
             self.history = self.history \
-                ._replace(position=self.history.position + self.lines)
+                ._replace(position=self.history.position + mid)
 
             for y in range(self.lines - mid):
                 self.buffer[y] = self.buffer[y + mid]

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -43,7 +43,7 @@ def test_index():
     for _ in range(screen.lines * screen.lines):
         screen.index()
 
-    assert len(screen.history.top) == 25  # pages // 2 * lines
+    assert len(screen.history.top) == 25
 
 
 def test_reverse_index():
@@ -111,7 +111,7 @@ def test_prev_page():
 
     # a) first page up.
     screen.prev_page()
-    assert screen.history.position == 36
+    assert screen.history.position == 38
     assert len(screen.buffer) == screen.lines
     assert screen.display == [
         "35  ",
@@ -135,7 +135,7 @@ def test_prev_page():
 
     # b) second page up.
     screen.prev_page()
-    assert screen.history.position == 32
+    assert screen.history.position == 36
     assert len(screen.buffer) == screen.lines
     assert screen.display == [
         "33  ",
@@ -172,7 +172,7 @@ def test_prev_page():
     ]
 
     screen.prev_page()
-    assert screen.history.position == 45
+    assert screen.history.position == 47
     assert screen.display == [
         "43   ",
         "44   ",
@@ -356,7 +356,7 @@ def test_next_page():
     screen.prev_page()
     screen.prev_page()
     screen.next_page()
-    assert screen.history.position == 45
+    assert screen.history.position == 47
     assert screen.history.top
     assert chars(screen.history.bottom, screen.columns) == [
         "23   ",
@@ -377,7 +377,7 @@ def test_next_page():
     screen.prev_page()
     screen.next_page()
     screen.next_page()
-    assert screen.history.position == 45
+    assert screen.history.position == 47
     assert len(screen.buffer) == screen.lines
     assert screen.display == [
         "18   ",

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -40,10 +40,10 @@ def test_index():
     assert screen.history.top[-1] == line
 
     # c) rotation.
-    for _ in range(screen.lines * screen.lines):
+    for _ in range(screen.history.size * 2):
         screen.index()
 
-    assert len(screen.history.top) == 25
+    assert len(screen.history.top) == 50
 
 
 def test_reverse_index():

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -188,7 +188,41 @@ def test_prev_page():
         "     ",
     ]
 
-    # d) same with cursor in the middle of the screen.
+    # d) with a ratio other than 0.5
+    screen = pyte.HistoryScreen(4, 4, history=40, ratio=0.75)
+    screen.set_mode(mo.LNM)
+
+    for idx in range(screen.lines * 10):
+        screen.draw(str(idx))
+        screen.linefeed()
+
+    assert screen.history.top
+    assert not screen.history.bottom
+    assert screen.history.position == 40
+    assert screen.display == [
+        "37  ",
+        "38  ",
+        "39  ",
+        "    "
+    ]
+
+    screen.prev_page()
+    assert screen.history.position == 37
+    assert screen.display == [
+        "34  ",
+        "35  ",
+        "36  ",
+        "37  "
+    ]
+
+    assert len(screen.history.bottom) == 3
+    assert chars(screen.history.bottom, screen.columns) == [
+        "38  ",
+        "39  ",
+        "    "
+    ]
+
+    # e) same with cursor in the middle of the screen.
     screen = pyte.HistoryScreen(5, 5, history=50)
     screen.set_mode(mo.LNM)
 

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -249,11 +249,11 @@ def test_prev_page():
     assert screen.history.position == screen.lines
     assert len(screen.buffer) == screen.lines
     assert screen.display == [
-        "21   ",
-        "22   ",
-        "23   ",
-        "24   ",
-        "25   "
+        "1    ",
+        "2    ",
+        "3    ",
+        "4    ",
+        "5    "
     ]
 
     while screen.history.position < screen.history.size:
@@ -296,11 +296,11 @@ def test_prev_page():
     assert screen.history.position == screen.lines
     assert len(screen.buffer) == screen.lines
     assert screen.display == [
-        "21   ",
-        "22   ",
-        "23   ",
-        "24   ",
-        "25   "
+        "1    ",
+        "2    ",
+        "3    ",
+        "4    ",
+        "5    "
     ]
 
     while screen.history.position < screen.history.size:


### PR DESCRIPTION
I'm using the `HistoryScreen` with a page up/down ratio of less than 0.5, but I've been encountering some issues.

When updating the history position, `prev_page` and `next_page` appears to make the assumption that a whole screen worth of lines has been moved. This means that, with a ratio of 0.5, the position moves twice as fast as the screen does through the history. This PR modifies this behaviour so that the position is incremented by the number of lines moved.

On implementing this change, I encountered the problem that I would reach the top of the top buffer before reaching a history position of 0. This is due to the fact that the top history buffer is created with a `maxlen` of half the history size. Before the above fix, this length was not an issue as the top of the buffer would be reached at the same size as the position reaching zero when ratio remained at the default of 0.5. This PR therefore also modifies the top buffer to have a `maxlen` equal to the history size.

Finally, these changes broke the test for the logic which determined if the cursor is hidden. This logic has been modified to use `history.position == history.size` to determine if at the bottom of the history.