### PR TITLE
Encode CSI as C0 control code

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@ Version 0.8.0-dev
 
 - Modify logic around tracking position in the ``HistoryScreen``, allowing the
   full history to be access. See PR #96 on GitHub.
+- Send C0 encoded CSI instead of C1, avoiding compatibility issues with
+  unicode. See issue #99 on GitHub.
 
 Version 0.7.0
 -------------

--- a/pyte/control.py
+++ b/pyte/control.py
@@ -61,8 +61,8 @@ ESC = "\x1b"
 #: *Delete*: Is ignored.
 DEL = "\x7f"
 
-#: *Control sequence introducer*: An equivalent for ``ESC [``.
-CSI = "\x9b"
+#: *Control sequence introducer*.
+CSI = ESC + "["
 
 #: *String terminator*.
 ST = "\x9c"

--- a/pyte/control.py
+++ b/pyte/control.py
@@ -62,7 +62,9 @@ ESC = "\x1b"
 DEL = "\x7f"
 
 #: *Control sequence introducer*.
-CSI = ESC + "["
+CSI_C0 = ESC + "["
+CSI_C1 = "\x9b"
+CSI = CSI_C0
 
 #: *String terminator*.
 ST = "\x9c"

--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -129,7 +129,7 @@ class Stream(object):
 
     #: A regular expression pattern matching everything what can be
     #: considered plain text.
-    _special = set([ctrl.ESC, ctrl.CSI, ctrl.NUL, ctrl.DEL, ctrl.OSC])
+    _special = set([ctrl.ESC, ctrl.CSI_C1, ctrl.NUL, ctrl.DEL, ctrl.OSC])
     _special.update(basic)
     _text_pattern = re.compile(
         "[^" + "".join(map(re.escape, _special)) + "]+")
@@ -213,7 +213,7 @@ class Stream(object):
         draw = listener.draw
         debug = listener.debug
 
-        ESC, CSI = ctrl.ESC, ctrl.CSI
+        ESC, CSI_C1 = ctrl.ESC, ctrl.CSI_C1
         OSC, ST = ctrl.OSC, ctrl.ST
         SP_OR_GT = ctrl.SP + ">"
         NUL_OR_DEL = ctrl.NUL + ctrl.DEL
@@ -251,7 +251,7 @@ class Stream(object):
                 #    are noop.
                 char = yield
                 if char == "[":
-                    char = CSI  # Go to CSI.
+                    char = CSI_C1  # Go to CSI.
                 elif char == "]":
                     char = OSC  # Go to OSC.
                 else:
@@ -279,7 +279,7 @@ class Stream(object):
                     continue
 
                 basic_dispatch[char]()
-            elif char == CSI:
+            elif char == CSI_C1:
                 # All parameters are unsigned, positive decimal integers, with
                 # the most significant digit sent first. Any parameter greater
                 # than 9999 is set to 9999. If you do not specify a value, a 0


### PR DESCRIPTION
Encoding the control sequence introducer as the C1 control code `'\x9b'`
seems to clash with Unicode, which appears to not reserve this character
for control use. This PR replaces it with the C0 control code `'\x1b['`
(ESC + [), which should avoid this issue.

For additional context, see issue #99.