### PR TITLE
Handle dispatch failure

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,7 +8,8 @@ Version 0.8.1-dev
 
 - Yet another fix of ``Screen.set_margins`` for the case of CSI
   with no arguments. See issue #61 on GitHub.
-
+- Restart ``Stream`` finite state machine on error when parsing control
+  sequence.
 
 Version 0.8.0
 -------------


### PR DESCRIPTION
This PR restarts the parser finite state machine if it exits with an exception. Prior to this change, failures in the handler would leave the stream in an unusable state, since calling `.send()` on the parser finite state machine would raise `StopIteration`.