### PR TITLE
Reverse complete screen on setting DECSCNM mode

### DIFF
--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -210,8 +210,11 @@ class Screen(object):
        for a description of the presentational component, implemented
        by ``Screen``.
     """
-    #: An empty character with default foreground and background colors.
-    default_char = Char(data=" ", fg="default", bg="default")
+    @property
+    def default_char(self):
+        """An empty character with default foreground and background colors."""
+        reverse = mo.DECSCNM in self.mode
+        return Char(data=" ", fg="default", bg="default", reverse=reverse)
 
     def __init__(self, columns, lines):
         self.savepoints = []
@@ -383,6 +386,7 @@ class Screen(object):
         # Mark all displayed characters as reverse.
         if mo.DECSCNM in modes:
             for line in self.buffer.values():
+                line.default = self.default_char
                 for x in line:
                     line[x] = line[x]._replace(reverse=True)
 
@@ -418,6 +422,7 @@ class Screen(object):
 
         if mo.DECSCNM in modes:
             for line in self.buffer.values():
+                line.default = self.default_char
                 for x in line:
                     line[x] = line[x]._replace(reverse=False)
 

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -261,10 +261,12 @@ def test_set_mode():
     for line in range(3):
         for char in tolist(screen)[line]:
             assert char.reverse
+    assert screen.default_char.reverse
     screen.reset_mode(mo.DECSCNM)
     for line in range(3):
         for char in tolist(screen)[line]:
             assert not char.reverse
+    assert not screen.default_char.reverse
 
     # Test mo.DECTCEM mode
     screen = update(pyte.Screen(3, 3), ["sam", "is ", "foo"])


### PR DESCRIPTION
Right now, pyte will reverse all displayed characters when the DECSCNM mode is set. However, this leaves the empty parts of the screen non-reversed because the default value of the buffer `defaultdict` is a non-reversed Char.

This PR makes `Screen.default_char` a property that depends on the mode DECSNM being set, and in addition replaces the default value on the lines that have been already been displayed.

This behaviour can be tested with `vttest` menu 2. 