### PR TITLE
Exit OSC on receipt of C0 string terminator

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,8 @@ Version 0.8.0-dev
 - Fixed `DECSCNM` handling bug. The attributes of ``Screen.default_char``
   were not reversed leaving all blank characters as-is. See PR #102 on
   GitHub. Thanks to @zblz!
+- Correctly terminate OSC mode in ``Stream`` on receipt of a C0 encoded ``ST``
+  character.
 
 Version 0.7.0
 -------------

--- a/pyte/control.py
+++ b/pyte/control.py
@@ -67,7 +67,11 @@ CSI_C1 = "\x9b"
 CSI = CSI_C0
 
 #: *String terminator*.
-ST = "\x9c"
+ST_C0 = ESC + "\\"
+ST_C1 = "\x9c"
+ST = ST_C0
 
 #: *Operating system command*.
-OSC = "\x9d"
+OSC_C0 = ESC + "]"
+OSC_C1 = "\x9d"
+OSC = OSC_C0

--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -336,7 +336,7 @@ class Stream(object):
                     char = yield
                     if char == ESC:
                         char += yield
-                    if char in {ctrl.ST_C0, ctrl.ST_C1, ctrl.BEL}:
+                    if char in [ctrl.ST_C0, ctrl.ST_C1, ctrl.BEL]:
                         break
                     else:
                         param += char

--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -334,7 +334,9 @@ class Stream(object):
                 param = ""
                 while True:
                     char = yield
-                    if char == ST_C1 or char == ctrl.BEL:
+                    if char == ESC:
+                        char += yield
+                    if char in {ctrl.ST_C0, ctrl.ST_C1, ctrl.BEL}:
                         break
                     else:
                         param += char

--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -129,7 +129,7 @@ class Stream(object):
 
     #: A regular expression pattern matching everything what can be
     #: considered plain text.
-    _special = set([ctrl.ESC, ctrl.CSI_C1, ctrl.NUL, ctrl.DEL, ctrl.OSC])
+    _special = set([ctrl.ESC, ctrl.CSI_C1, ctrl.NUL, ctrl.DEL, ctrl.OSC_C1])
     _special.update(basic)
     _text_pattern = re.compile(
         "[^" + "".join(map(re.escape, _special)) + "]+")
@@ -214,7 +214,7 @@ class Stream(object):
         debug = listener.debug
 
         ESC, CSI_C1 = ctrl.ESC, ctrl.CSI_C1
-        OSC, ST = ctrl.OSC, ctrl.ST
+        OSC_C1, ST_C1 = ctrl.OSC_C1, ctrl.ST_C1
         SP_OR_GT = ctrl.SP + ">"
         NUL_OR_DEL = ctrl.NUL + ctrl.DEL
         CAN_OR_SUB = ctrl.CAN + ctrl.SUB
@@ -253,7 +253,7 @@ class Stream(object):
                 if char == "[":
                     char = CSI_C1  # Go to CSI.
                 elif char == "]":
-                    char = OSC  # Go to OSC.
+                    char = OSC_C1  # Go to OSC.
                 else:
                     if char == "#":
                         sharp_dispatch[(yield)]()
@@ -324,7 +324,7 @@ class Stream(object):
                             else:
                                 csi_dispatch[char](*params)
                             break  # CSI is finished.
-            elif char == OSC:
+            elif char == OSC_C1:
                 code = yield
                 if code == "R":
                     continue  # Reset palette. Not implemented.
@@ -334,7 +334,7 @@ class Stream(object):
                 param = ""
                 while True:
                     char = yield
-                    if char == ST or char == ctrl.BEL:
+                    if char == ST_C1 or char == ctrl.BEL:
                         break
                     else:
                         param += char

--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -214,12 +214,13 @@ class Stream(object):
         debug = listener.debug
 
         ESC, CSI_C1 = ctrl.ESC, ctrl.CSI_C1
-        OSC_C1, ST_C1 = ctrl.OSC_C1, ctrl.ST_C1
+        OSC_C1 = ctrl.OSC_C1
         SP_OR_GT = ctrl.SP + ">"
         NUL_OR_DEL = ctrl.NUL + ctrl.DEL
         CAN_OR_SUB = ctrl.CAN + ctrl.SUB
         ALLOWED_IN_CSI = "".join([ctrl.BEL, ctrl.BS, ctrl.HT, ctrl.LF,
                                   ctrl.VT, ctrl.FF, ctrl.CR])
+        OSC_TERMINATORS = set([ctrl.ST_C0, ctrl.ST_C1, ctrl.BEL])
 
         def create_dispatcher(mapping):
             return defaultdict(lambda: debug, dict(
@@ -336,7 +337,7 @@ class Stream(object):
                     char = yield
                     if char == ESC:
                         char += yield
-                    if char in [ctrl.ST_C0, ctrl.ST_C1, ctrl.BEL]:
+                    if char in OSC_TERMINATORS:
                         break
                     else:
                         param += char

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -184,19 +184,19 @@ def test_set_title_icon_name():
     stream = pyte.Stream(screen)
 
     # a) set only icon name
-    stream.feed(ctrl.OSC + "1;foo" + ctrl.ST)
+    stream.feed(ctrl.OSC_C1 + "1;foo" + ctrl.ST_C1)
     assert screen.icon_name == "foo"
 
     # b) set only title
-    stream.feed(ctrl.OSC + "2;foo" + ctrl.ST)
+    stream.feed(ctrl.OSC_C1 + "2;foo" + ctrl.ST_C1)
     assert screen.title == "foo"
 
     # c) set both icon name and title
-    stream.feed(ctrl.OSC + "0;bar" + ctrl.ST)
+    stream.feed(ctrl.OSC_C1 + "0;bar" + ctrl.ST_C1)
     assert screen.title == screen.icon_name == "bar"
 
     # d) set both icon name and title then terminate with BEL
-    stream.feed(ctrl.OSC + "0;bar" + ctrl.BEL)
+    stream.feed(ctrl.OSC_C1 + "0;bar" + ctrl.BEL)
     assert screen.title == screen.icon_name == "bar"
 
     # e) test ➜ ('\xe2\x9e\x9c') symbol, that contains string terminator \x9c

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -179,24 +179,30 @@ def test_control_characters():
     assert handler.args == (10, 10)
 
 
-def test_set_title_icon_name():
+@pytest.mark.parametrize('osc,st', [
+    (ctrl.OSC_C0, ctrl.ST_C0),
+    (ctrl.OSC_C0, ctrl.ST_C1),
+    (ctrl.OSC_C1, ctrl.ST_C0),
+    (ctrl.OSC_C1, ctrl.ST_C1)
+])
+def test_set_title_icon_name(osc, st):
     screen = pyte.Screen(80, 24)
     stream = pyte.Stream(screen)
 
     # a) set only icon name
-    stream.feed(ctrl.OSC_C1 + "1;foo" + ctrl.ST_C1)
+    stream.feed(osc + "1;foo" + st)
     assert screen.icon_name == "foo"
 
     # b) set only title
-    stream.feed(ctrl.OSC_C1 + "2;foo" + ctrl.ST_C1)
+    stream.feed(osc + "2;foo" + st)
     assert screen.title == "foo"
 
     # c) set both icon name and title
-    stream.feed(ctrl.OSC_C1 + "0;bar" + ctrl.ST_C1)
+    stream.feed(osc + "0;bar" + st)
     assert screen.title == screen.icon_name == "bar"
 
     # d) set both icon name and title then terminate with BEL
-    stream.feed(ctrl.OSC_C1 + "0;bar" + ctrl.BEL)
+    stream.feed(osc + "0;bar" + st)
     assert screen.title == screen.icon_name == "bar"
 
     # e) test ➜ ('\xe2\x9e\x9c') symbol, that contains string terminator \x9c


### PR DESCRIPTION
Currently, the pyte stream control sequence parser can enter OSC parsing mode on receipt of either C0 or C1 OSC characters (`'\x1b]'` and `'\x9d'` respectively), but would only exit OSC mode on receipt of a BEL (`'\x07'`) or C1 ST character (`'\x9c'`), but not a C0 ST character (`'\x1b\\'`, i.e. `ESC \`).

As a result of this, an OSC control character sequence using the C0 string terminator would cause the parser to get 'stuck' in the OSC mode and no further input would be handled correctly.

This PR modifies the parser to collect an additional character after receiving an ESC before applying the 'is this a ST or BEL' logic. We may wish to consider introducing a similar logic for the main loop where C0 OSC and CSI characters are converted to C1 ones (though this would be in a separate PR).