### PR TITLE
Allow extra args on `Screen.erase_in_display`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,7 +8,9 @@ Version 0.8.1-dev
 
 - Yet another fix of ``Screen.set_margins`` for the case of CSI
   with no arguments. See issue #61 on GitHub.
-
+- Accept additional positional arguments to ``Screen.erase_in_display``, as
+  some clear implementations include a ``;`` after the first parameter causing
+  pyte to assme a ``0`` second parameter.
 
 Version 0.8.0
 -------------

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -764,7 +764,7 @@ class Screen(object):
         for x in interval:
             line[x] = self.cursor.attrs
 
-    def erase_in_display(self, how=0, private=False):
+    def erase_in_display(self, how=0, *args, **kwargs):
         """Erases display in a specific way.
 
         Character attributes are set to cursor attributes.
@@ -1191,9 +1191,10 @@ class HistoryScreen(Screen):
         super(HistoryScreen, self).reset()
         self._reset_history()
 
-    def erase_in_display(self, how=0):
+    def erase_in_display(self, how=0, *args, **kwargs):
         """Overloaded to reset history state."""
-        super(HistoryScreen, self).erase_in_display(how)
+
+        super(HistoryScreen, self).erase_in_display(how, *args, **kwargs)
 
         if how == 3:
             self._reset_history()

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -1286,6 +1286,49 @@ def test_erase_in_display():
                               "     "]
     assert tolist(screen) == [[screen.default_char] * 5] * 5
 
+    # d) erase with private mode
+    screen = update(pyte.Screen(5, 5),
+                    ["sam i",
+                     "s foo",
+                     "but a",
+                     "re yo",
+                     "u?   "], colored=[2, 3])
+    screen.erase_in_display(3, private=True)
+    assert screen.display == ["     ",
+                              "     ",
+                              "     ",
+                              "     ",
+                              "     "]
+
+    # e) erase with extra args
+    screen = update(pyte.Screen(5, 5),
+                    ["sam i",
+                     "s foo",
+                     "but a",
+                     "re yo",
+                     "u?   "], colored=[2, 3])
+    args = [3, 0]
+    screen.erase_in_display(*args)
+    assert screen.display == ["     ",
+                              "     ",
+                              "     ",
+                              "     ",
+                              "     "]
+
+    # f) erase with extra args and private
+    screen = update(pyte.Screen(5, 5),
+                    ["sam i",
+                     "s foo",
+                     "but a",
+                     "re yo",
+                     "u?   "], colored=[2, 3])
+    screen.erase_in_display(*args, private=True)
+    assert screen.display == ["     ",
+                              "     ",
+                              "     ",
+                              "     ",
+                              "     "]
+
 
 def test_cursor_up():
     screen = pyte.Screen(10, 10)


### PR DESCRIPTION
The `clear` implementation provided in Ubuntu sends the following control sequence:

```
\033[3;J\033[H\033[2J
```

This can be found by running:

```
/usr/bin/clear | sed -n l                                                                        
```

The first part of this sequence, `\033[3;J`, differs from that expected by the specification, from the sequence sent by other `clear` implementations, and from that expected by pyte, which is `\033[3J`.

The pyte `Stream` parser currently reads the `;` and assumes there will a second argument, which defaults to `0`. This `0` is passed as a second positional argument to `erase_in_display`, which clashes with the `private` keyword argument.

This PR modifies `erase_in_display` to accept any number of positional arguments by use of `*args`, while still catching `private` with `**kwargs` (though as before, `private` is unused.