### PR TITLE
Handle color resets inside multiple attributes

### DIFF
--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -969,7 +969,10 @@ class Screen(object):
 
         while attrs:
             attr = attrs.pop()
-            if attr in g.FG_ANSI:
+            if attr == 0:
+                # Reset all attributes.
+                replace.update(self.default_char._asdict())
+            elif attr in g.FG_ANSI:
                 replace["fg"] = g.FG_ANSI[attr]
             elif attr in g.BG:
                 replace["bg"] = g.BG_ANSI[attr]

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -149,6 +149,16 @@ def test_reset_resets_colors():
     assert screen.cursor.attrs == screen.default_char
 
 
+def test_reset_works_between_attributes():
+    screen = pyte.Screen(2, 2)
+    assert tolist(screen) == [[screen.default_char, screen.default_char]] * 2
+
+    # Red fg, reset, red bg
+    screen.select_graphic_rendition(31, 0, 41)
+    assert screen.cursor.attrs.fg == "default"
+    assert screen.cursor.attrs.bg == "red"
+
+
 def test_multi_attribs():
     screen = pyte.Screen(2, 2)
     assert tolist(screen) == [[screen.default_char, screen.default_char]] * 2


### PR DESCRIPTION
Reset was ignored in cases like \e[31;0;41m, causing colors to
bleed where they shouldn't.

I tested the change by running zsh, mc and ipython inside pyte.