### PR TITLE
Change DECCOLM behaviour

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,8 @@ Version 0.8.0-dev
   character.
 - Allowed resetting cursor attributes in the middle of the SGR sequence.
   See PR#109 on GiHub. Thanks @andreivasiliu!
+- On exit from `DECCOLM` mode, restore the terminal width from before entering
+  `DECCOLM` mode.
 
 Version 0.7.0
 -------------

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -282,6 +282,8 @@ class Screen(object):
         self.cursor = Cursor(0, 0)
         self.cursor_position()
 
+        self.saved_columns = None
+
     def resize(self, lines=None, columns=None):
         """Resize the screen to the given size.
 
@@ -375,6 +377,7 @@ class Screen(object):
         # When DECOLM mode is set, the screen is erased and the cursor
         # moves to the home position.
         if mo.DECCOLM in modes:
+            self.saved_columns = self.columns
             self.resize(columns=132)
             self.erase_in_display(2)
             self.cursor_position()
@@ -413,7 +416,9 @@ class Screen(object):
 
         # Lines below follow the logic in :meth:`set_mode`.
         if mo.DECCOLM in modes:
-            self.resize(columns=80)
+            if self.columns == 132 and self.saved_columns is not None:
+                self.resize(columns=self.saved_columns)
+                self.saved_columns = None
             self.erase_in_display(2)
             self.cursor_position()
 

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -256,7 +256,7 @@ def test_set_mode():
     assert screen.cursor.x == 0
     assert screen.cursor.y == 0
     screen.reset_mode(mo.DECCOLM)
-    assert screen.columns == 80
+    assert screen.columns == 3
 
     # Test mo.DECOM mode
     screen = update(pyte.Screen(3, 3), ["sam", "is ", "foo"])


### PR DESCRIPTION
Currently, exiting DECCOLM mode always set the width of the terminal to 80 columns. This PR changes the behaviour to restore the number of columns the terminal had before entering DECCOLM mode.

This change is motivated by the fact that running `reset` in Ubuntu outputs (among other things) the control sequence `\x1b[?3;4l`, meaning reset private modes 3 and 4. Resetting private mode 3, DECCOLM, causes the screen width to be set at 80 characters. This causes a deleterious experience for the users of our web terminal program being developed around pyte. For example:

* A user creates a terminal of 100 character width
* Some time later, the user uses the `reset` command, sending the DECCOLM reset control sequence
* The user's terminal is modified to 80 characters in width

This produces a confusing experience for our users, as despite never having had the terminal in 80 characters width previously, it is now in that width until modified again by the user.

This PR modifies the behaviour in pyte to match that of xterm.js, which is to store the terminal width on setting DECCOLM mode and restoring that (if existing) on resetting DECCOLM.