### PR TITLE
Avoid ord() raising TypeError cause empty char

### DIFF
--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -239,7 +239,12 @@ class Screen(object):
                     continue
                 char = line[x].data
                 assert sum(map(wcwidth, char[1:])) == 0
-                is_wide_char = wcwidth(char[0]) == 2
+
+                if len(char) == 0:
+                    is_wide_char = False
+                else:
+                    is_wide_char = wcwidth(char[0]) == 2
+
                 yield char
 
         return ["".join(render(self.buffer[y])) for y in range(self.lines)]


### PR DESCRIPTION
https://github.com/jquast/wcwidth/issues/24