### PR TITLE
Fix DeprecationWarning: invalid escape sequence in __main__.py

### DIFF
--- a/pyte/__main__.py
+++ b/pyte/__main__.py
@@ -5,7 +5,7 @@
 
     Command-line tool for "disassembling" escape and CSI sequences::
 
-        $ echo -e "\e[Jfoo" | python -m pyte
+        $ echo -e "\\e[Jfoo" | python -m pyte
         ERASE_IN_DISPLAY 0
         DRAW f
         DRAW o


### PR DESCRIPTION
Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>