### PR TITLE
Don't skip text after an unprintable character

### DIFF
--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -524,7 +524,7 @@ class Screen(object):
                     self.buffer[self.cursor.y - 1][self.columns - 1] = \
                         last._replace(data=normalized)
             else:
-                break  # Unprintable character or doesn't advance the cursor.
+                continue  # Unprintable character or doesn't advance the cursor.
 
             # .. note:: We can't use :meth:`cursor_forward()`, because that
             #           way, we'll never know when to linefeed.


### PR DESCRIPTION
Reproduction example:

```python
import pyte
screen = pyte.Screen(80, 24)
screen.draw("\x02abacaba")
print(screen.display[0])  # returns spaces only, should return abacaba
```