### PR TITLE
Added UTF8 option in __init__ (constructor) to emulate terminals that do not start in UTF8 mode

### DIFF
--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -135,10 +135,10 @@ class Stream(object):
         "[^" + "".join(map(re.escape, _special)) + "]+")
     del _special
 
-    def __init__(self, screen=None, strict=True):
+    def __init__(self, screen=None, strict=True, start_utf8=True):
         self.listener = None
         self.strict = strict
-        self.use_utf8 = True
+        self.use_utf8 = start_utf8
 
         if screen is not None:
             self.attach(screen)


### PR DESCRIPTION
It was only after digging through a lot of pyte's code that I realized that it isn't "broken"; instead, it just starts in UTF8 mode. However, a lot of software out there runs in non-UTF8 mode from the start and never switches to it using the %@ command (in my case, this was the Python curses programs I've been working with.) This results in "boxes" and other DEC special graphics characters (usually supported by BVT100 terminals) showing up as lower-case Latin alphabetical characters (l,k,m, etc).

Adding a kwarg to the __init__ of the Stream class allows the terminal to be explicitly started in ISO 2022 mode.