### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyte/control.py
+++ b/pyte/control.py
@@ -14,7 +14,7 @@
 """
 from __future__ import unicode_literals
 
-#: *Space*: Not suprisingly -- ``" "``.
+#: *Space*: Not surprisingly -- ``" "``.
 SP = " "
 
 #: *Null*: Does nothing.
@@ -23,7 +23,7 @@ NUL = "\x00"
 #: *Bell*: Beeps.
 BEL = "\x07"
 
-#: *Backspace*: Backspace one column, but not past the begining of the
+#: *Backspace*: Backspace one column, but not past the beginning of the
 #: line.
 BS = "\x08"
 

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -370,7 +370,7 @@ class Screen(object):
         :param list modes: modes to set, where each mode is a constant
                            from :mod:`pyte.modes`.
         """
-        # Private mode codes are shifted, to be distingiushed from non
+        # Private mode codes are shifted, to be distinguished from non
         # private ones.
         if kwargs.get("private"):
             modes = [mode << 5 for mode in modes]
@@ -754,7 +754,7 @@ class Screen(object):
               including cursor position.
             * ``2`` -- Erases complete line.
         :param bool private: when ``True`` only characters marked as
-                             eraseable are affected **not implemented**.
+                             erasable are affected **not implemented**.
         """
         self.dirty.add(self.cursor.y)
         if how == 0:
@@ -783,7 +783,7 @@ class Screen(object):
               are erased and changed to single-width. Cursor does not
               move.
         :param bool private: when ``True`` only characters marked as
-                             eraseable are affected **not implemented**.
+                             erasable are affected **not implemented**.
 
         .. versionchanged:: 0.8.1
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -112,7 +112,7 @@ def test_erase_in_display():
     screen.erase_in_display()
     assert screen.dirty == set(range(screen.cursor.y, screen.lines))
 
-    # b) from the begining of the screen to cursor.
+    # b) from the beginning of the screen to cursor.
     screen.dirty.clear()
     screen.erase_in_display(1)
     assert screen.dirty == set(range(0, screen.cursor.y + 1))

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -693,7 +693,7 @@ def test_clear_tabstops():
     screen = pyte.Screen(10, 10)
     screen.clear_tab_stop(3)
 
-    # a) clear a tabstop at current cusor location
+    # a) clear a tabstop at current cursor location
     screen.cursor.x = 1
     screen.set_tab_stop()
     screen.cursor.x = 5


### PR DESCRIPTION
There are small typos in:
- pyte/control.py
- pyte/screens.py
- tests/test_diff.py
- tests/test_screen.py

Fixes:
- Should read `erasable` rather than `eraseable`.
- Should read `beginning` rather than `begining`.
- Should read `surprisingly` rather than `suprisingly`.
- Should read `distinguished` rather than `distingiushed`.
- Should read `cursor` rather than `cusor`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md