### PR TITLE
Screen optimizations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ Contributors
 - Byron Roosa
 - Andrew Crozier
 - @eight04
+- Martin Di Paola @eldipa

--- a/benchmark.py
+++ b/benchmark.py
@@ -10,6 +10,11 @@
         .....................
         ls.input: Mean +- std dev: 644 ns +- 23 ns
 
+    Environment variables:
+
+    BENCHMARK: the input file to feed pyte's Stream and render on the Screen
+    GEOMETRY: the dimensions of the screen with format "<lines>x<cols>" (default 24x80)
+
     :copyright: (c) 2016-2021 by pyte authors and contributors,
                     see AUTHORS for details.
     :license: LGPL, see LICENSE for more details.
@@ -28,20 +33,25 @@ except ImportError:
 import pyte
 
 
-def make_benchmark(path, screen_cls):
+def make_benchmark(path, screen_cls, columns, lines):
     with io.open(path, "rt", encoding="utf-8") as handle:
         data = handle.read()
 
-    stream = pyte.Stream(screen_cls(80, 24))
+    stream = pyte.Stream(screen_cls(columns, lines))
     return partial(stream.feed, data)
 
 
 if __name__ == "__main__":
     benchmark = os.environ["BENCHMARK"]
-    sys.argv.extend(["--inherit-environ", "BENCHMARK"])
+    lines, columns = map(int, os.environ.get("GEOMETRY", "24x80").split('x'))
+    sys.argv.extend(["--inherit-environ", "BENCHMARK,GEOMETRY"])
 
-    runner = Runner()
+    runner = Runner(metadata={
+        'input_file': benchmark,
+        'columns': columns,
+        'lines': lines
+        })
 
     for screen_cls in [pyte.Screen, pyte.DiffScreen, pyte.HistoryScreen]:
         name = os.path.basename(benchmark) + "->" + screen_cls.__name__
-        runner.bench_func(name, make_benchmark(benchmark, screen_cls))
+        runner.bench_func(name, make_benchmark(benchmark, screen_cls, columns, lines))

--- a/benchmark.py
+++ b/benchmark.py
@@ -10,6 +10,10 @@
         .....................
         ls.input: Mean +- std dev: 644 ns +- 23 ns
 
+        $ BENCHMARK=tests/captured/ls.input GEOMETRY=1024x1024 python benchmark.py -o results.json
+        .....................
+        ls.input: Mean +- std dev: 644 ns +- 23 ns
+
     Environment variables:
 
     BENCHMARK: the input file to feed pyte's Stream and render on the Screen
@@ -32,26 +36,54 @@ except ImportError:
 
 import pyte
 
-
-def make_benchmark(path, screen_cls, columns, lines):
+def setup(path, screen_cls, columns, lines):
     with io.open(path, "rt", encoding="utf-8") as handle:
         data = handle.read()
 
-    stream = pyte.Stream(screen_cls(columns, lines))
+    screen = screen_cls(columns, lines)
+    stream = pyte.Stream(screen)
+
+    return data, screen, stream
+
+def make_stream_feed_benchmark(path, screen_cls, columns, lines):
+    data, _, stream = setup(path, screen_cls, columns, lines)
     return partial(stream.feed, data)
 
+def make_screen_display_benchmark(path, screen_cls, columns, lines):
+    data, screen, stream = setup(path, screen_cls, columns, lines)
+    stream.feed(data)
+    return lambda: screen.display
+
+def make_screen_reset_benchmark(path, screen_cls, columns, lines):
+    data, screen, stream = setup(path, screen_cls, columns, lines)
+    stream.feed(data)
+    return screen.reset
+
+def make_screen_resize_half_benchmark(path, screen_cls, columns, lines):
+    data, screen, stream = setup(path, screen_cls, columns, lines)
+    stream.feed(data)
+    return partial(screen.resize, lines=lines//2, columns=columns//2)
 
 if __name__ == "__main__":
     benchmark = os.environ["BENCHMARK"]
     lines, columns = map(int, os.environ.get("GEOMETRY", "24x80").split('x'))
     sys.argv.extend(["--inherit-environ", "BENCHMARK,GEOMETRY"])
 
-    runner = Runner(metadata={
+    runner = Runner()
+
+    metadata = {
         'input_file': benchmark,
         'columns': columns,
         'lines': lines
-        })
+        }
 
+    benchmark_name = os.path.basename(benchmark)
     for screen_cls in [pyte.Screen, pyte.DiffScreen, pyte.HistoryScreen]:
-        name = os.path.basename(benchmark) + "->" + screen_cls.__name__
-        runner.bench_func(name, make_benchmark(benchmark, screen_cls, columns, lines))
+        screen_cls_name = screen_cls.__name__
+        for make_test in (make_stream_feed_benchmark, make_screen_display_benchmark, make_screen_reset_benchmark, make_screen_resize_half_benchmark):
+            scenario = make_test.__name__[5:-10] # remove make_ and _benchmark
+
+            name = f"[{scenario} {lines}x{columns}] {benchmark_name}->{screen_cls_name}"
+            metadata.update({'scenario': scenario, 'screen_cls': screen_cls_name})
+            runner.bench_func(name, make_test(benchmark, screen_cls, columns, lines), metadata=metadata)
+

--- a/benchmark.py
+++ b/benchmark.py
@@ -37,11 +37,11 @@ except ImportError:
 import pyte
 
 def setup(path, screen_cls, columns, lines):
-    with io.open(path, "rt", encoding="utf-8") as handle:
+    with io.open(path, "rb") as handle:
         data = handle.read()
 
     screen = screen_cls(columns, lines)
-    stream = pyte.Stream(screen)
+    stream = pyte.ByteStream(screen)
 
     return data, screen, stream
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -36,59 +36,63 @@ except ImportError:
 
 import pyte
 
-def setup(path, screen_cls, columns, lines):
+def setup(path, screen_cls, columns, lines, optimize_conf):
     with io.open(path, "rb") as handle:
         data = handle.read()
 
-    if screen_cls == pyte.Screen:
-        extra_args = {'track_dirty_lines': False}
-    else:
-        extra_args = {}
+    extra_args = {}
+    if optimize_conf:
+        extra_args = {
+                'track_dirty_lines': False,
+                'disable_display_graphic': True,
+                }
 
     screen = screen_cls(columns, lines, **extra_args)
     stream = pyte.ByteStream(screen)
 
     return data, screen, stream
 
-def make_stream_feed_benchmark(path, screen_cls, columns, lines):
-    data, _, stream = setup(path, screen_cls, columns, lines)
+def make_stream_feed_benchmark(path, screen_cls, columns, lines, optimize_conf):
+    data, _, stream = setup(path, screen_cls, columns, lines, optimize_conf)
     return partial(stream.feed, data)
 
-def make_screen_display_benchmark(path, screen_cls, columns, lines):
-    data, screen, stream = setup(path, screen_cls, columns, lines)
+def make_screen_display_benchmark(path, screen_cls, columns, lines, optimize_conf):
+    data, screen, stream = setup(path, screen_cls, columns, lines, optimize_conf)
     stream.feed(data)
     return lambda: screen.display
 
-def make_screen_reset_benchmark(path, screen_cls, columns, lines):
-    data, screen, stream = setup(path, screen_cls, columns, lines)
+def make_screen_reset_benchmark(path, screen_cls, columns, lines, optimize_conf):
+    data, screen, stream = setup(path, screen_cls, columns, lines, optimize_conf)
     stream.feed(data)
     return screen.reset
 
-def make_screen_resize_half_benchmark(path, screen_cls, columns, lines):
-    data, screen, stream = setup(path, screen_cls, columns, lines)
+def make_screen_resize_half_benchmark(path, screen_cls, columns, lines, optimize_conf):
+    data, screen, stream = setup(path, screen_cls, columns, lines, optimize_conf)
     stream.feed(data)
     return partial(screen.resize, lines=lines//2, columns=columns//2)
 
 if __name__ == "__main__":
     benchmark = os.environ["BENCHMARK"]
     lines, columns = map(int, os.environ.get("GEOMETRY", "24x80").split('x'))
-    sys.argv.extend(["--inherit-environ", "BENCHMARK,GEOMETRY"])
+    optimize_conf = int(os.environ.get("OPTIMIZECONF", "0"))
+    sys.argv.extend(["--inherit-environ", "BENCHMARK,GEOMETRY,OPTIMIZECONF"])
 
     runner = Runner()
 
     metadata = {
         'input_file': benchmark,
         'columns': columns,
-        'lines': lines
+        'lines': lines,
+        'optimize_conf': optimize_conf
         }
 
     benchmark_name = os.path.basename(benchmark)
-    for screen_cls in [pyte.Screen, pyte.DiffScreen, pyte.HistoryScreen]:
+    for screen_cls in [pyte.Screen, pyte.HistoryScreen]:
         screen_cls_name = screen_cls.__name__
         for make_test in (make_stream_feed_benchmark, make_screen_display_benchmark, make_screen_reset_benchmark, make_screen_resize_half_benchmark):
             scenario = make_test.__name__[5:-10] # remove make_ and _benchmark
 
             name = f"[{scenario} {lines}x{columns}] {benchmark_name}->{screen_cls_name}"
             metadata.update({'scenario': scenario, 'screen_cls': screen_cls_name})
-            runner.bench_func(name, make_test(benchmark, screen_cls, columns, lines), metadata=metadata)
+            runner.bench_func(name, make_test(benchmark, screen_cls, columns, lines, optimize_conf), metadata=metadata)
 

--- a/benchmark.py
+++ b/benchmark.py
@@ -40,7 +40,12 @@ def setup(path, screen_cls, columns, lines):
     with io.open(path, "rb") as handle:
         data = handle.read()
 
-    screen = screen_cls(columns, lines)
+    if screen_cls == pyte.Screen:
+        extra_args = {'track_dirty_lines': False}
+    else:
+        extra_args = {}
+
+    screen = screen_cls(columns, lines, **extra_args)
     stream = pyte.ByteStream(screen)
 
     return data, screen, stream

--- a/full_benchmark.sh
+++ b/full_benchmark.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/bash
+
+if [ "$#" != "1" ]; then
+    echo "Usage benchmark.sh <outputfile>"
+    exit 1
+fi
+outputfile=$1
+
+if [ ! -f benchmark.py ]; then
+    echo "File benchmark.py missing. Are you in the home folder of pyte project?"
+    exit 1
+fi
+
+for inputfile in $(ls -1 tests/captured/*.input); do
+    export GEOMETRY=24x80
+    echo "$inputfile - $GEOMETRY"
+    echo "======================"
+    BENCHMARK=$inputfile python benchmark.py --append $outputfile
+
+    export GEOMETRY=240x800
+    echo "$inputfile - $GEOMETRY"
+    echo "======================"
+    BENCHMARK=$inputfile python benchmark.py --append $outputfile
+
+    export GEOMETRY=2400x8000
+    echo "$inputfile - $GEOMETRY"
+    echo "======================"
+    BENCHMARK=$inputfile python benchmark.py --append $outputfile
+
+    export GEOMETRY=24x8000
+    echo "$inputfile - $GEOMETRY"
+    echo "======================"
+    BENCHMARK=$inputfile python benchmark.py --append $outputfile
+
+    export GEOMETRY=2400x80
+    echo "$inputfile - $GEOMETRY"
+    echo "======================"
+    BENCHMARK=$inputfile python benchmark.py --append $outputfile
+done

--- a/full_benchmark.sh
+++ b/full_benchmark.sh
@@ -1,9 +1,21 @@
 #!/usr/bin/bash
 
-if [ "$#" != "1" ]; then
+if [ "$#" != "1" -a "$#" != "2" ]; then
     echo "Usage benchmark.sh <outputfile>"
+    echo "Usage benchmark.sh <outputfile> tracemalloc"
     exit 1
 fi
+
+if [ "$2" = "tracemalloc" ]; then
+    tracemalloc="--tracemalloc"
+elif [ "$2" = "" ]; then
+    tracemalloc=""
+else
+    echo "Usage benchmark.sh <outputfile>"
+    echo "Usage benchmark.sh <outputfile> tracemalloc"
+    exit 1
+fi
+
 outputfile=$1
 
 if [ ! -f benchmark.py ]; then
@@ -15,25 +27,25 @@ for inputfile in $(ls -1 tests/captured/*.input); do
     export GEOMETRY=24x80
     echo "$inputfile - $GEOMETRY"
     echo "======================"
-    BENCHMARK=$inputfile python benchmark.py --append $outputfile
+    BENCHMARK=$inputfile python benchmark.py $tracemalloc --append $outputfile
 
     export GEOMETRY=240x800
     echo "$inputfile - $GEOMETRY"
     echo "======================"
-    BENCHMARK=$inputfile python benchmark.py --append $outputfile
+    BENCHMARK=$inputfile python benchmark.py $tracemalloc --append $outputfile
 
     export GEOMETRY=2400x8000
     echo "$inputfile - $GEOMETRY"
     echo "======================"
-    BENCHMARK=$inputfile python benchmark.py --append $outputfile
+    BENCHMARK=$inputfile python benchmark.py $tracemalloc --append $outputfile
 
     export GEOMETRY=24x8000
     echo "$inputfile - $GEOMETRY"
     echo "======================"
-    BENCHMARK=$inputfile python benchmark.py --append $outputfile
+    BENCHMARK=$inputfile python benchmark.py $tracemalloc --append $outputfile
 
     export GEOMETRY=2400x80
     echo "$inputfile - $GEOMETRY"
     echo "======================"
-    BENCHMARK=$inputfile python benchmark.py --append $outputfile
+    BENCHMARK=$inputfile python benchmark.py $tracemalloc --append $outputfile
 done

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -907,6 +907,13 @@ class Screen:
             begin = bisect_left(non_empty_y, top + 1)
             end = bisect_right(non_empty_y, bottom, begin)
 
+            # the top line must be unconditionally removed
+            # this pop is required because it may happen that
+            # the next line (top + 1) is empty and therefore
+            # the for-loop above didn't overwrite the line before
+            # (top + 1 - 1, aka top)
+            pop(top, None)
+
             to_move = non_empty_y[begin:end]
             for y in to_move:
                 buffer[y-1] = pop(y)
@@ -929,6 +936,13 @@ class Screen:
             non_empty_y = sorted(buffer)
             begin = bisect_left(non_empty_y, top)
             end = bisect_right(non_empty_y, bottom - 1, begin)
+
+            # the bottom line must be unconditionally removed
+            # this pop is required because it may happen that
+            # the previous line (bottom - 1) is empty and therefore
+            # the for-loop above didn't overwrite the line after
+            # (bottom - 1 + 1, aka bottom)
+            pop(bottom, None)
 
             to_move = non_empty_y[begin:end]
             for y in reversed(to_move):

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -60,6 +60,17 @@ Savepoint = namedtuple("Savepoint", [
     "wrap"
 ])
 
+CharStyle = namedtuple("CharStyle", [
+    "fg",
+    "bg",
+    "bold",
+    "italics",
+    "underscore",
+    "strikethrough",
+    "reverse",
+    "blink",
+])
+
 
 class Char:
     """A single styled on-screen character.
@@ -83,30 +94,52 @@ class Char:
     """
     __slots__ = (
         "data",
-        "fg",
-        "bg",
-        "bold",
-        "italics",
-        "underscore",
-        "strikethrough",
-        "reverse",
-        "blink",
         "width",
+        "style",
         )
+
+    # List the properties of this Char instance including its style's properties
+    # The order of this _fields is maintained for backward compatibility
+    _fields = ("data",) + CharStyle._fields + ("width",)
 
     def __init__(self, data=" ", fg="default", bg="default", bold=False,
                 italics=False, underscore=False,
                 strikethrough=False, reverse=False, blink=False, width=wcwidth(" ")):
         self.data = data
-        self.fg = fg
-        self.bg = bg
-        self.bold = bold
-        self.italics = italics
-        self.underscore = underscore
-        self.strikethrough = strikethrough
-        self.reverse = reverse
-        self.blink = blink
         self.width = width
+        self.style = CharStyle(fg, bg, bold, italics, underscore, strikethrough, reverse, blink)
+
+    @property
+    def fg(self):
+        return self.style.fg
+
+    @property
+    def bg(self):
+        return self.style.bg
+
+    @property
+    def bold(self):
+        return self.style.bold
+
+    @property
+    def italics(self):
+        return self.style.italics
+
+    @property
+    def underscore(self):
+        return self.style.underscore
+
+    @property
+    def strikethrough(self):
+        return self.style.strikethrough
+
+    @property
+    def reverse(self):
+        return self.style.reverse
+
+    @property
+    def blink(self):
+        return self.style.blink
 
     def _replace(self, **kargs):
         fields = self._asdict()
@@ -114,21 +147,19 @@ class Char:
         return Char(**fields)
 
     def _asdict(self):
-        return {name: getattr(self, name) for name in self.__slots__}
+        return {name: getattr(self, name) for name in self._fields}
 
     def __eq__(self, other):
         if not isinstance(other, Char):
             raise TypeError()
 
-        return all(getattr(self, name) == getattr(other, name) for name in self.__slots__)
+        return all(getattr(self, name) == getattr(other, name) for name in self._fields)
 
     def __ne__(self, other):
         if not isinstance(other, Char):
             raise TypeError()
 
-        return any(getattr(self, name) != getattr(other, name) for name in self.__slots__)
-
-    _fields = __slots__
+        return any(getattr(self, name) != getattr(other, name) for name in self._fields)
 
 class Cursor:
     """Screen cursor.

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -483,7 +483,10 @@ class Screen:
     @property
     def display(self):
         """A :func:`list` of screen lines as unicode strings."""
-        padding = self.default_char.data
+        # screen.default_char is always the space character
+        # We can skip the lookup of it and set the padding char
+        # directly
+        padding = " "
 
         prev_y = -1
         output = []

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -487,12 +487,13 @@ class Screen:
     def default_line(self):
         return Line(self.default_char)
 
-    def __init__(self, columns, lines, track_dirty_lines=True):
+    def __init__(self, columns, lines, track_dirty_lines=True, disable_display_graphic=False):
         self.savepoints = []
         self.columns = columns
         self.lines = lines
         self._buffer = Buffer(self)
         self.dirty = set() if track_dirty_lines else NullSet()
+        self.disabled_display_graphic = disable_display_graphic
 
         self._default_style = CharStyle(
                 fg="default", bg="default", bold=False,
@@ -1592,7 +1593,7 @@ class Screen:
         replace = {}
 
         # Fast path for resetting all attributes.
-        if not attrs or attrs == (0, ):
+        if not attrs or attrs == (0, ) or self.disabled_display_graphic:
             self.cursor.attrs = self.default_char
             return
         else:

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -667,8 +667,8 @@ class Screen:
         if mo.DECSCNM in modes:
             for line in self._buffer.values():
                 line.default = self.default_char
-                for x in line:
-                    line[x].style = line[x].style._replace(reverse=True)
+                for char in line.values():
+                    char.style = char.style._replace(reverse=True)
 
             self.select_graphic_rendition(7)  # +reverse.
 
@@ -705,8 +705,8 @@ class Screen:
         if mo.DECSCNM in modes:
             for line in self._buffer.values():
                 line.default = self.default_char
-                for x in line:
-                    line[x].style = line[x].style._replace(reverse=False)
+                for char in line.values():
+                    char.style = char.style._replace(reverse=False)
 
             self.select_graphic_rendition(27)  # -reverse.
 
@@ -1338,8 +1338,9 @@ class Screen:
         self.dirty.update(range(self.lines))
         style = self._default_style
         for y in range(self.lines):
+            line = self._buffer[y]
             for x in range(self.columns):
-                self._buffer[y].write_data(x, "E", wcwidth("E"), style)
+                line.write_data(x, "E", wcwidth("E"), style)
 
     def select_graphic_rendition(self, *attrs):
         """Set display attributes.

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -1715,11 +1715,13 @@ class HistoryScreen(Screen):
         :param str event: event name, for example ``"linefeed"``.
         """
         if event in ["prev_page", "next_page"]:
+            columns = self.columns
             for line in self._buffer.values():
                 pop = line.pop
-                for x in line:
-                    if x > self.columns:
-                        pop(x)
+                non_empty_x = sorted(line.keys())
+                begin = bisect_left(non_empty_x, columns)
+                for x in non_empty_x[begin:]:
+                    pop(x)
 
         # If we're at the bottom of the history buffer and `DECTCEM`
         # mode is set -- show the cursor.

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -675,7 +675,7 @@ class Screen:
         # Mark all displayed characters as reverse.
         if mo.DECSCNM in modes:
             for line in self._buffer.values():
-                line.default = self.default_char
+                line.default.style = line.default.style._replace(reverse=True)
                 for char in line.values():
                     char.style = char.style._replace(reverse=True)
 
@@ -713,7 +713,7 @@ class Screen:
 
         if mo.DECSCNM in modes:
             for line in self._buffer.values():
-                line.default = self.default_char
+                line.default.style = line.default.style._replace(reverse=False)
                 for char in line.values():
                     char.style = char.style._replace(reverse=False)
 

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -1096,19 +1096,47 @@ class Screen:
         if not line:
             return
 
-        for x in range(self.columns, self.cursor.x - 1, -1):
-            new_x = x + count
-            if new_x <= self.columns:
-                if x in line:
-                    line[x + count] = line.pop(x)
-                else:
-                    # this is equivalent to:
-                    #   line[new_x] = line[x]
-                    # where line[x] does not exist so line[new_x]
-                    # should not exist either
-                    line.pop(new_x, None)
-            else:
-                line.pop(x, None)
+        pop = line.pop
+
+        # Note: the following is optimized for the case of long lines
+        # that are not very densely populated, the amount of count
+        # to insert is small and the cursor is not very close to the right
+        # end.
+        non_empty_x = sorted(line)
+        begin = bisect_left(non_empty_x, self.cursor.x)
+        end = bisect_left(non_empty_x, self.columns - count)
+
+        to_move = reversed(non_empty_x[begin:end])
+
+        # cursor.x
+        # |
+        # V    to_move
+        # |---------------|
+        #   0   1   x   3   4   5      count = 2  (x means empty)
+        #
+        #   x   x   0   1   4   3      (first for-loop without the inner loop: the "4" is wrong)
+        #
+        #   x   x   0   1   x   3      (first for-loop with the inner loop: the "4" is removed)
+        next_x = self.columns - count
+        for x in to_move:
+            # Notice how if (x + 1) == (next_x) then you know
+            # that no empty char are in between this x and the next one
+            # and therefore the range() loop gets empty.
+            # In other cases, (x + 1) < (next_x)
+            for z in range(x + 1 + count, next_x + count):
+                pop(z, None)
+
+            # it may look weird but the current "x" is the "next_x"
+            # of the next iteration because we are iterating to_move
+            # backwards
+            next_x = x
+            line[x + count] = pop(x)
+
+        # between the cursor.x and the last moved char
+        # we may have that should be emptied
+        for z in range(self.cursor.x, next_x + count):
+            pop(z, None)
+
 
     def delete_characters(self, count=None):
         """Delete the indicated # of characters, starting with the
@@ -1129,11 +1157,37 @@ class Screen:
         if not line:
             return
 
-        for x in range(self.cursor.x, self.columns):
-            if x + count <= self.columns:
-                line[x] = line.pop(x + count, self.default_char.copy())
-            else:
-                line.pop(x, None)
+        pop = line.pop
+
+        non_empty_x = sorted(line)
+        begin = bisect_left(non_empty_x, self.cursor.x + count)
+
+        to_move = non_empty_x[begin:]
+
+        # cursor.x
+        #   |
+        #   |          to_move
+        #   V     |---------------|
+        #   0   1   x   3   4   x      count = 2  (x means empty)
+        #
+        #   0   3   4   3   x   x
+        #
+        #   x   3   4   x   x   x
+        prev_x = self.cursor.x + count - 1
+        for x in to_move:
+            # Notice how if (x - 1) == (prev_x) then you know
+            # that no empty char are in between this x and the prev one
+            # and therefore the range() loop gets empty.
+            # In other cases, (prev_x + 1) > (x)
+            for z in range(prev_x + 1 + count, x + count):
+                pop(z, None)
+
+            prev_x = x
+            line[x - count] = pop(x)
+
+        # this delete from the last written to the last read
+        for z in range(prev_x + 1 - count, prev_x + 1):
+            pop(z, None)
 
     def erase_characters(self, count=None):
         """Erase the indicated # of characters, starting with the

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -1748,14 +1748,17 @@ class HistoryScreen(Screen):
     _wrapped = set(Stream.events)
     _wrapped.update(["next_page", "prev_page"])
 
-    def __init__(self, columns, lines, history=100, ratio=.5):
+    def __init__(self, columns, lines, history=100, ratio=.5,
+                 track_dirty_lines=True, disable_display_graphic=False):
         self.history = History(deque(maxlen=history),
                                deque(maxlen=history),
                                float(ratio),
                                history,
                                history)
 
-        super(HistoryScreen, self).__init__(columns, lines)
+        super(HistoryScreen, self).__init__(columns, lines,
+                track_dirty_lines=track_dirty_lines,
+                disable_display_graphic=disable_display_graphic)
 
     def _make_wrapper(self, event, handler):
         def inner(*args, **kwargs):

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -432,8 +432,8 @@ class Screen:
        (see :meth:`index` and :meth:`reverse_index`). Characters added
        outside the scrolling region do not make the screen to scroll.
 
-       The value is ``None`` if margins are set to screen boundaries,
-       otherwise -- a pair 0-based top and bottom line indices.
+       The margins are a pair 0-based top and bottom line indices
+       set to screen boundaries by default.
 
     .. attribute:: charset
 
@@ -587,7 +587,7 @@ class Screen:
         """
         self.dirty.update(range(self.lines))
         self._buffer.clear()
-        self.margins = None
+        self.margins = Margins(0, self.lines - 1)
 
         self.mode = set([mo.DECAWM, mo.DECTCEM])
 
@@ -660,10 +660,10 @@ class Screen:
         """
         # XXX 0 corresponds to the CSI with no parameters.
         if (top is None or top == 0) and bottom is None:
-            self.margins = None
+            self.margins = Margins(0, self.lines - 1)
             return
 
-        margins = self.margins or Margins(0, self.lines - 1)
+        margins = self.margins
 
         # Arguments are 1-based, while :attr:`margins` are zero
         # based -- so we have to decrement them by one. We also
@@ -940,7 +940,7 @@ class Screen:
         """Move the cursor down one line in the same column. If the
         cursor is at the last line, create a new line at the bottom.
         """
-        top, bottom = self.margins or Margins(0, self.lines - 1)
+        top, bottom = self.margins
         if self.cursor.y == bottom:
             buffer = self._buffer
             pop = buffer.pop
@@ -970,7 +970,7 @@ class Screen:
         """Move the cursor up one line in the same column. If the cursor
         is at the first line, create a new line at the top.
         """
-        top, bottom = self.margins or Margins(0, self.lines - 1)
+        top, bottom = self.margins
         if self.cursor.y == top:
             buffer = self._buffer
             pop = buffer.pop
@@ -1069,7 +1069,7 @@ class Screen:
         :param count: number of lines to insert.
         """
         count = count or 1
-        top, bottom = self.margins or Margins(0, self.lines - 1)
+        top, bottom = self.margins
 
         # If cursor is outside scrolling margins it -- do nothin'.
         if top <= self.cursor.y <= bottom:
@@ -1108,7 +1108,7 @@ class Screen:
         :param int count: number of lines to delete.
         """
         count = count or 1
-        top, bottom = self.margins or Margins(0, self.lines - 1)
+        top, bottom = self.margins
 
         # If cursor is outside scrolling margins -- do nothin'.
         if top <= self.cursor.y <= bottom:
@@ -1441,7 +1441,7 @@ class Screen:
                                  cursor is bounded by top and and bottom
                                  margins, instead of ``[0; lines - 1]``.
         """
-        if (use_margins or mo.DECOM in self.mode) and self.margins is not None:
+        if (use_margins or mo.DECOM in self.mode):
             top, bottom = self.margins
         else:
             top, bottom = 0, self.lines - 1
@@ -1454,7 +1454,7 @@ class Screen:
 
         :param int count: number of lines to skip.
         """
-        top, _bottom = self.margins or Margins(0, self.lines - 1)
+        top, _bottom = self.margins
         self.cursor.y = max(self.cursor.y - (count or 1), top)
 
     def cursor_up1(self, count=None):
@@ -1472,7 +1472,7 @@ class Screen:
 
         :param int count: number of lines to skip.
         """
-        _top, bottom = self.margins or Margins(0, self.lines - 1)
+        _top, bottom = self.margins
         self.cursor.y = min(self.cursor.y + (count or 1), bottom)
 
     def cursor_down1(self, count=None):
@@ -1522,7 +1522,7 @@ class Screen:
 
         # If origin mode (DECOM) is set, line number are relative to
         # the top scrolling margin.
-        if self.margins is not None and mo.DECOM in self.mode:
+        if mo.DECOM in self.mode:
             line += self.margins.top
 
             # Cursor is not allowed to move out of the scrolling region.
@@ -1817,7 +1817,7 @@ class HistoryScreen(Screen):
 
     def index(self):
         """Overloaded to update top history with the removed lines."""
-        top, bottom = self.margins or Margins(0, self.lines - 1)
+        top, bottom = self.margins
 
         if self.cursor.y == bottom:
             self.history.top.append(self.buffer[top])
@@ -1826,7 +1826,7 @@ class HistoryScreen(Screen):
 
     def reverse_index(self):
         """Overloaded to update bottom history with the removed lines."""
-        top, bottom = self.margins or Margins(0, self.lines - 1)
+        top, bottom = self.margins
 
         if self.cursor.y == top:
             self.history.bottom.append(self.buffer[bottom])

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -1010,14 +1010,16 @@ class Screen:
         """Move to the next tab space, or the end of the screen if there
         aren't anymore left.
         """
-        for stop in sorted(self.tabstops):
-            if self.cursor.x < stop:
-                column = stop
-                break
-        else:
-            column = self.columns - 1
+        tabstops = sorted(self.tabstops)
 
-        self.cursor.x = column
+        # use bisect_right because self.cursor.x must not
+        # be included
+        at = bisect_right(tabstops, self.cursor.x)
+        if at == len(tabstops):
+            # no tabstops found, set the x to the end of the screen
+            self.cursor.x = self.columns - 1
+        else:
+            self.cursor.x = tabstops[at]
 
     def backspace(self):
         """Move cursor to the left one or keep it in its position if
@@ -1425,7 +1427,7 @@ class Screen:
             # present, or silently fails if otherwise.
             self.tabstops.discard(self.cursor.x)
         elif how == 3:
-            self.tabstops = set()  # Clears all horizontal tab stops.
+            self.tabstops.clear()  # Clears all horizontal tab stops.
 
     def ensure_hbounds(self):
         """Ensure the cursor is within horizontal screen bounds."""

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -1271,7 +1271,6 @@ class Screen:
                 del buffer[y]
 
         else:
-            write_data = line.write_data
             data = self.cursor.attrs.data
             width = self.cursor.attrs.width
             style = self.cursor.attrs.style

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -103,6 +103,7 @@ class BufferStats(namedtuple("_BufferStats", [
     "columns",
     "lines",
     "falses",
+    "blanks",
     "occupacy",
     "min",
     "max",
@@ -123,16 +124,18 @@ class BufferStats(namedtuple("_BufferStats", [
 
         if self.empty:
             return bstats + \
-                    "line entries: {0: >3}/{1} ({2:.2f}), falses: {3:> 3} ({4:.2f})\n{5}".format(
+                    "line entries: {0: >3}/{1} ({2:.2f}), falses: {3:> 3} ({4:.2f}), blanks: {5:> 3} ({6:.2f})\n{7}".format(
                     self.entries, self.lines, self.occupacy,
                     self.falses, self.falses/self.entries,
+                    self.blanks, self.blanks/self.entries,
                     "\n".join("{0: >3}: {1}".format(x, stats) for x, stats in self.line_stats)
                     )
         else:
             return bstats + \
-                    "line entries: {0: >3}/{1} ({2:.2f}), falses: {3:> 3} ({4:.2f}); range: [{5: >3} - {6: >3}], len: {7: >3} ({8:.2f})\n{9}".format(
+                    "line entries: {0: >3}/{1} ({2:.2f}), falses: {3:> 3} ({4:.2f}), blanks: {5:> 3} ({6:.2f}); range: [{7: >3} - {8: >3}], len: {9: >3} ({10:.2f})\n{11}".format(
                     self.entries, self.lines, self.occupacy,
                     self.falses, self.falses/self.entries,
+                    self.blanks, self.blanks/self.entries,
                     self.min, self.max, self.span, self.span/self.lines,
                     "\n".join("{0: >3}: {1}".format(x, stats) for x, stats in self.line_stats)
                     )
@@ -469,6 +472,7 @@ class Screen:
                 columns=self.columns,
                 lines=self.lines,
                 falses=len([line for line in buffer.values() if not line]),
+                blanks=len([line for line in buffer.values() if all(char.data == " " for char in line.values())]),
                 occupacy=len(buffer)/self.lines,
                 min=min(buffer) if buffer else None,
                 max=max(buffer) if buffer else None,

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -658,8 +658,8 @@ class Screen:
                 pop = line.pop
                 non_empty_x = sorted(line)
                 begin = bisect_left(non_empty_x, columns)
-                for x in non_empty_x[begin:]:
-                    pop(x)
+
+                list(map(pop, non_empty_x[begin:]))
 
         self.lines, self.columns = lines, columns
         self.set_margins()
@@ -1286,8 +1286,7 @@ class Screen:
             begin = bisect_left(non_empty_x, self.cursor.x)
             end = bisect_left(non_empty_x, self.cursor.x + count, begin)
 
-            for x in non_empty_x[begin:end]:
-                pop(x)
+            list(map(pop, non_empty_x[begin:end]))
 
             # the line may end up being empty, delete it from the buffer (*)
             if not line:
@@ -1337,8 +1336,7 @@ class Screen:
             begin = bisect_left(non_empty_x, low)
             end = bisect_left(non_empty_x, high, begin)
 
-            for x in non_empty_x[begin:end]:
-                pop(x)
+            list(map(pop, non_empty_x[begin:end]))
 
             # the line may end up being empty, delete it from the buffer (*)
             if not line:
@@ -1401,12 +1399,12 @@ class Screen:
         # If a deleted line is then requested, a new line will
         # be added with screen.default_char as its default char
         if self.default_char == self.cursor.attrs:
+            pop = buffer.pop
             non_empty_y = sorted(buffer)
             begin = bisect_left(non_empty_y, top)  # inclusive
             end = bisect_left(non_empty_y, bottom, begin) # exclusive
 
-            for y in non_empty_y[begin:end]:
-                del buffer[y]
+            list(map(pop, non_empty_y[begin:end]))
 
         else:
             data = self.cursor.attrs.data
@@ -1795,10 +1793,10 @@ class HistoryScreen(Screen):
             columns = self.columns
             for line in self._buffer.values():
                 pop = line.pop
-                non_empty_x = sorted(line.keys())
+                non_empty_x = sorted(line)
                 begin = bisect_left(non_empty_x, columns)
-                for x in non_empty_x[begin:]:
-                    pop(x)
+
+                list(map(pop, non_empty_x[begin:]))
 
         # If we're at the bottom of the history buffer and `DECTCEM`
         # mode is set -- show the cursor.

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -622,8 +622,11 @@ class Screen:
 
         if columns < self.columns:
             for line in self._buffer.values():
-                for x in range(columns, self.columns):
-                    line.pop(x, None)
+                pop = line.pop
+                non_empty_x = sorted(line)
+                begin = bisect_left(non_empty_x, columns)
+                for x in non_empty_x[begin:]:
+                    pop(x)
 
         self.lines, self.columns = lines, columns
         self.set_margins()

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -61,18 +61,7 @@ Savepoint = namedtuple("Savepoint", [
 ])
 
 
-class Char(namedtuple("Char", [
-    "data",
-    "fg",
-    "bg",
-    "bold",
-    "italics",
-    "underscore",
-    "strikethrough",
-    "reverse",
-    "blink",
-    "width",
-])):
+class Char:
     """A single styled on-screen character.
 
     :param str data: unicode character. Invariant: ``len(data) == 1``.
@@ -92,15 +81,54 @@ class Char(namedtuple("Char", [
                        ``False``.
     :param bool width: the width in terms of cells to display this char.
     """
-    __slots__ = ()
+    __slots__ = (
+        "data",
+        "fg",
+        "bg",
+        "bold",
+        "italics",
+        "underscore",
+        "strikethrough",
+        "reverse",
+        "blink",
+        "width",
+        )
 
-    def __new__(cls, data=" ", fg="default", bg="default", bold=False,
+    def __init__(self, data=" ", fg="default", bg="default", bold=False,
                 italics=False, underscore=False,
                 strikethrough=False, reverse=False, blink=False, width=wcwidth(" ")):
-        return super(Char, cls).__new__(cls, data, fg, bg, bold, italics,
-                                        underscore, strikethrough, reverse,
-                                        blink, width)
+        self.data = data
+        self.fg = fg
+        self.bg = bg
+        self.bold = bold
+        self.italics = italics
+        self.underscore = underscore
+        self.strikethrough = strikethrough
+        self.reverse = reverse
+        self.blink = blink
+        self.width = width
 
+    def _replace(self, **kargs):
+        fields = self._asdict()
+        fields.update(kargs)
+        return Char(**fields)
+
+    def _asdict(self):
+        return {name: getattr(self, name) for name in self.__slots__}
+
+    def __eq__(self, other):
+        if not isinstance(other, Char):
+            raise TypeError()
+
+        return all(getattr(self, name) == getattr(other, name) for name in self.__slots__)
+
+    def __ne__(self, other):
+        if not isinstance(other, Char):
+            raise TypeError()
+
+        return any(getattr(self, name) != getattr(other, name) for name in self.__slots__)
+
+    _fields = __slots__
 
 class Cursor:
     """Screen cursor.

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -1050,9 +1050,8 @@ class Screen:
         if top <= self.cursor.y <= bottom:
             self.dirty.update(range(self.cursor.y, self.lines))
             for y in range(self.cursor.y, bottom + 1):
-                if y + count <= bottom:
-                    if y + count in self._buffer:
-                        self._buffer[y] = self._buffer.pop(y + count)
+                if y + count <= bottom and y + count in self._buffer:
+                    self._buffer[y] = self._buffer.pop(y + count)
                 else:
                     self._buffer.pop(y, None)
 

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -348,9 +348,8 @@ class BufferView:
         self._buffer = screen._buffer
 
     def __getitem__(self, y):
-        try:
-            line = self._buffer[y]
-        except KeyError:
+        line = self._buffer.get(y)
+        if line is None:
             line = Line(self._screen.default_char)
 
         return LineView(line)

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -25,6 +25,7 @@
     :license: LGPL, see LICENSE for more details.
 """
 
+import collections
 import copy
 import json
 import math
@@ -376,6 +377,26 @@ class BufferView:
     def __len__(self):
         return self._screen.lines
 
+class NullSet(collections.abc.MutableSet):
+    ''' Implementation of a set that it is always empty. '''
+    def __contains__(self, x):
+        return False
+
+    def __iter__(self):
+        return iter(set())
+
+    def __len__(self):
+        return 0
+
+    def add(self, x):
+        return
+
+    def discard(self, x):
+        return
+
+    def update(self, it):
+        return
+
 class Screen:
     """
     A screen is an in-memory matrix of characters that represents the
@@ -455,12 +476,12 @@ class Screen:
     def default_line(self):
         return Line(self.default_char)
 
-    def __init__(self, columns, lines):
+    def __init__(self, columns, lines, track_dirty_lines=True):
         self.savepoints = []
         self.columns = columns
         self.lines = lines
         self._buffer = defaultdict(lambda: Line(self.default_char))
-        self.dirty = set()
+        self.dirty = set() if track_dirty_lines else NullSet()
 
         self._default_style = CharStyle(
                 fg="default", bg="default", bold=False,
@@ -1878,7 +1899,8 @@ class HistoryScreen(Screen):
                     # anyways (aka, we remove the old ones)
                     pop(y, None)
 
-            self.dirty = set(range(self.lines))
+            self.dirty.clear()
+            self.dirty.update(range(self.lines))
 
     def next_page(self):
         """Move the screen page down through the history buffer."""
@@ -1936,7 +1958,8 @@ class HistoryScreen(Screen):
                     # anyways (aka, we remove the old ones)
                     pop(y, None)
 
-            self.dirty = set(range(self.lines))
+            self.dirty.clear()
+            self.dirty.update(range(self.lines))
 
 
 class DebugEvent(namedtuple("Event", "name args kwargs")):

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -256,7 +256,6 @@ class Screen:
                     is_wide_char = False
                     continue
                 char = cell.data
-                assert sum(map(wcwidth, char[1:])) == 0
                 is_wide_char = wcwidth(char[0]) == 2
                 display_line.append(char)
 

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -237,6 +237,26 @@ class Char:
 
         return any(getattr(self, name) != getattr(other, name) for name in self._fields)
 
+    def __repr__(self):
+        r = "'%s'" % self.data
+        attrs = []
+        if self.fg != "default":
+            attrs.append("fg=%s" % self.fg)
+        if self.bg != "default":
+            attrs.append("bg=%s" % self.bg)
+
+        for attrname in ['bold', 'italics', 'underscore',
+                'strikethrough', 'reverse', 'blink']:
+            val = getattr(self, attrname)
+            if val:
+                attrs.append("%s=%s" % (attrname, val))
+
+        if attrs:
+            r += " (" + (", ".join(attrs)) + ")"
+
+        return r
+
+
 class Cursor:
     """Screen cursor.
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
 pytest
-pyperf == 1.7.1
+pyperf >= 2.3.0
 wcwidth
 wheel

--- a/tests/helpers/asserts.py
+++ b/tests/helpers/asserts.py
@@ -1,0 +1,12 @@
+from wcwidth import wcwidth
+def consistency_asserts(screen):
+    # Ensure that all the cells in the buffer, if they have
+    # a data of 2 or more code points, they all sum up 0 width
+    # In other words, the width of the cell is determinated by the
+    # width of the first code point.
+    for y in range(screen.lines):
+        for x in range(screen.columns):
+            char = screen.buffer[y][x].data
+            assert sum(map(wcwidth, char[1:])) == 0
+
+

--- a/tests/helpers/asserts.py
+++ b/tests/helpers/asserts.py
@@ -6,7 +6,17 @@ def consistency_asserts(screen):
     # width of the first code point.
     for y in range(screen.lines):
         for x in range(screen.columns):
-            char = screen.buffer[y][x].data
-            assert sum(map(wcwidth, char[1:])) == 0
+            data = screen.buffer[y][x].data
+            assert sum(map(wcwidth, data[1:])) == 0
 
 
+    # Ensure consistency between the real width (computed here
+    # with wcwidth(...)) and the char.width attribute
+    for y in range(screen.lines):
+        for x in range(screen.columns):
+            char = screen.buffer[y][x]
+            if char.data:
+                assert wcwidth(char.data[0]) == char.width
+            else:
+                assert char.data == ""
+                assert char.width == 0

--- a/tests/helpers/asserts.py
+++ b/tests/helpers/asserts.py
@@ -36,3 +36,45 @@ def consistency_asserts(screen):
         max_x = max(non_empty_x) if non_empty_x else screen.columns - 1
 
         assert 0 <= min_x <= max_x < screen.columns
+
+
+def splice(seq, at, count, padding, margins=None):
+    ''' Take a sequence and add count padding objects at the
+        given position "at".
+        If count is negative, instead of adding, remove
+        objects at the given position and append the same
+        amount at the end.
+
+        If margins=(low, high) are given, operate between
+        the low and the high indexes of the sequence.
+        These are 0-based indexes, both inclusive.
+    '''
+
+    assert count != 0
+    assert isinstance(seq, list)
+
+    low, high = margins if margins else (0, len(seq) - 1)
+
+    if not (low <= at <= high):
+        return list(seq)
+
+    low_part = seq[:low]
+    high_part = seq[high+1:]
+
+    middle = seq[low:high+1]
+    at = at - low  # "at" now is an index of middle, not of seq.
+
+    if count < 0:   # remove mode
+        count = abs(count)
+        l = len(middle)
+        del middle[at:at+count]
+        middle += padding * (l - len(middle))
+    else:           # insert mode
+        middle = middle[:at] + padding * count + middle[at:]
+        del middle[-count:]
+
+    new = low_part + middle + high_part
+    assert len(new) == len(seq)
+    return new
+
+

--- a/tests/helpers/asserts.py
+++ b/tests/helpers/asserts.py
@@ -20,3 +20,19 @@ def consistency_asserts(screen):
             else:
                 assert char.data == ""
                 assert char.width == 0
+
+    # we check that no char is outside of the buffer
+    # we need to check the internal _buffer for this and do an educated
+    # check
+    non_empty_y = list(screen._buffer.keys())
+    min_y = min(non_empty_y) if non_empty_y else 0
+    max_y = max(non_empty_y) if non_empty_y else screen.lines - 1
+
+    assert 0 <= min_y <= max_y < screen.lines
+
+    for line in screen._buffer.values():
+        non_empty_x = list(line.keys())
+        min_x = min(non_empty_x) if non_empty_x else 0
+        max_x = max(non_empty_x) if non_empty_x else screen.columns - 1
+
+        assert 0 <= min_x <= max_x < screen.columns

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,6 +1,10 @@
 import pyte
 from pyte import modes as mo
 
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
+from asserts import consistency_asserts
+
 
 def test_mark_whole_screen():
     # .. this is straightforward -- make sure we have a dirty attribute
@@ -45,6 +49,7 @@ def test_mark_single_line():
         getattr(screen, method)()
         assert len(screen.dirty) == 1
         assert screen.cursor.y in screen.dirty
+        consistency_asserts(screen)
 
 
 def test_modes():
@@ -72,6 +77,7 @@ def test_index():
     screen.cursor_to_line(24)
     screen.index()
     assert screen.dirty == set(range(screen.lines))
+    consistency_asserts(screen)
 
 
 def test_reverse_index():
@@ -81,12 +87,14 @@ def test_reverse_index():
     # a) not at the top margin -- whole screen is dirty.
     screen.reverse_index()
     assert screen.dirty == set(range(screen.lines))
+    consistency_asserts(screen)
 
     # b) nothing is marked dirty.
     screen.dirty.clear()
     screen.cursor_to_line(screen.lines // 2)
     screen.reverse_index()
     assert not screen.dirty
+    consistency_asserts(screen)
 
 
 def test_insert_delete_lines():
@@ -97,6 +105,7 @@ def test_insert_delete_lines():
         screen.dirty.clear()
         getattr(screen, method)()
         assert screen.dirty == set(range(screen.cursor.y, screen.lines))
+        consistency_asserts(screen)
 
 
 def test_erase_in_display():
@@ -107,20 +116,24 @@ def test_erase_in_display():
     screen.dirty.clear()
     screen.erase_in_display()
     assert screen.dirty == set(range(screen.cursor.y, screen.lines))
+    consistency_asserts(screen)
 
     # b) from the beginning of the screen to cursor.
     screen.dirty.clear()
     screen.erase_in_display(1)
     assert screen.dirty == set(range(0, screen.cursor.y + 1))
+    consistency_asserts(screen)
 
     # c) whole screen.
     screen.dirty.clear()
     screen.erase_in_display(2)
     assert screen.dirty == set(range(0, screen.lines))
+    consistency_asserts(screen)
 
     screen.dirty.clear()
     screen.erase_in_display(3)
     assert screen.dirty == set(range(0, screen.lines))
+    consistency_asserts(screen)
 
 
 def test_draw_wrap():
@@ -132,6 +145,7 @@ def test_draw_wrap():
         screen.draw("g")
     assert screen.cursor.y == 0
     screen.dirty.clear()
+    consistency_asserts(screen)
 
     # now write one more character which should cause wrapping
     screen.draw("h")
@@ -139,6 +153,7 @@ def test_draw_wrap():
     # regression test issue #36 where the wrong line was marked as
     # dirty
     assert screen.dirty == set([0, 1])
+    consistency_asserts(screen)
 
 
 def test_draw_multiple_chars_wrap():
@@ -147,3 +162,4 @@ def test_draw_multiple_chars_wrap():
     screen.draw("1234567890")
     assert screen.cursor.y == 1
     assert screen.dirty == set([0, 1])
+    consistency_asserts(screen)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,8 +1,10 @@
-import os
+import os, sys
 
 import pyte
 from pyte import control as ctrl, modes as mo
 
+sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
+from asserts import consistency_asserts
 
 def chars(history_lines, columns):
     return ["".join(history_lines[y][x].data for x in range(columns))
@@ -96,6 +98,7 @@ def test_prev_page():
         "39  ",
         "    "
     ]
+    consistency_asserts(screen)
 
     assert chars(screen.history.top, screen.columns)[-4:] == [
         "33  ",
@@ -114,6 +117,7 @@ def test_prev_page():
         "37  ",
         "38  "
     ]
+    consistency_asserts(screen)
 
     assert chars(screen.history.top, screen.columns)[-4:] == [
         "31  ",
@@ -138,6 +142,7 @@ def test_prev_page():
         "35  ",
         "36  ",
     ]
+    consistency_asserts(screen)
 
     assert len(screen.history.bottom) == 4
     assert chars(screen.history.bottom, screen.columns) == [
@@ -165,6 +170,7 @@ def test_prev_page():
         "49   ",
         "     "
     ]
+    consistency_asserts(screen)
 
     screen.prev_page()
     assert screen.history.position == 47
@@ -175,6 +181,7 @@ def test_prev_page():
         "46   ",
         "47   "
     ]
+    consistency_asserts(screen)
 
     assert len(screen.history.bottom) == 3
     assert chars(screen.history.bottom, screen.columns) == [
@@ -200,6 +207,7 @@ def test_prev_page():
         "39  ",
         "    "
     ]
+    consistency_asserts(screen)
 
     screen.prev_page()
     assert screen.history.position == 37
@@ -209,6 +217,7 @@ def test_prev_page():
         "36  ",
         "37  "
     ]
+    consistency_asserts(screen)
 
     assert len(screen.history.bottom) == 3
     assert chars(screen.history.bottom, screen.columns) == [
@@ -235,6 +244,7 @@ def test_prev_page():
         "49   ",
         "     "
     ]
+    consistency_asserts(screen)
 
     screen.cursor_to_line(screen.lines // 2)
 
@@ -250,6 +260,7 @@ def test_prev_page():
         "4    ",
         "5    "
     ]
+    consistency_asserts(screen)
 
     while screen.history.position < screen.history.size:
         screen.next_page()
@@ -262,6 +273,7 @@ def test_prev_page():
         "49   ",
         "     "
     ]
+    consistency_asserts(screen)
 
     # e) same with cursor near the middle of the screen.
     screen = pyte.HistoryScreen(5, 5, history=50)
@@ -282,6 +294,7 @@ def test_prev_page():
         "49   ",
         "     "
     ]
+    consistency_asserts(screen)
 
     screen.cursor_to_line(screen.lines // 2 - 2)
 
@@ -297,6 +310,7 @@ def test_prev_page():
         "4    ",
         "5    "
     ]
+    consistency_asserts(screen)
 
     while screen.history.position < screen.history.size:
         screen.next_page()
@@ -310,6 +324,7 @@ def test_prev_page():
         "49   ",
         "     "
     ]
+    consistency_asserts(screen)
 
 
 def test_next_page():
@@ -332,6 +347,7 @@ def test_next_page():
         "24   ",
         "     "
     ]
+    consistency_asserts(screen)
 
     # a) page up -- page down.
     screen.prev_page()
@@ -346,6 +362,7 @@ def test_next_page():
         "24   ",
         "     "
     ]
+    consistency_asserts(screen)
 
     # b) double page up -- page down.
     screen.prev_page()
@@ -366,6 +383,7 @@ def test_next_page():
         "21   ",
         "22   "
     ]
+    consistency_asserts(screen)
 
     # c) double page up -- double page down
     screen.prev_page()
@@ -381,6 +399,7 @@ def test_next_page():
         "21   ",
         "22   "
     ]
+    consistency_asserts(screen)
 
 
 def test_ensure_width(monkeypatch):
@@ -402,6 +421,7 @@ def test_ensure_width(monkeypatch):
         "0024 ",
         "     "
     ]
+    consistency_asserts(screen)
 
     # Shrinking the screen should truncate the displayed lines following lines.
     screen.resize(5, 3)
@@ -416,6 +436,7 @@ def test_ensure_width(monkeypatch):
         "002",  # 21
         "002"   # 22
     ]
+    consistency_asserts(screen)
 
 
 def test_not_enough_lines():
@@ -436,6 +457,7 @@ def test_not_enough_lines():
         "4    ",
         "     "
     ]
+    consistency_asserts(screen)
 
     screen.prev_page()
     assert not screen.history.top
@@ -448,6 +470,7 @@ def test_not_enough_lines():
         "3    ",
         "4    ",
     ]
+    consistency_asserts(screen)
 
     screen.next_page()
     assert screen.history.top
@@ -459,6 +482,7 @@ def test_not_enough_lines():
         "4    ",
         "     "
     ]
+    consistency_asserts(screen)
 
 
 def test_draw(monkeypatch):
@@ -479,6 +503,7 @@ def test_draw(monkeypatch):
         "24   ",
         "     "
     ]
+    consistency_asserts(screen)
 
     # a) doing a pageup and then a draw -- expecting the screen
     #    to scroll to the bottom before drawing anything.
@@ -494,6 +519,7 @@ def test_draw(monkeypatch):
         "24   ",
         "x    "
     ]
+    consistency_asserts(screen)
 
 
 def test_cursor_is_hidden(monkeypatch):

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -28,13 +28,13 @@ def test_index():
     line = screen.buffer[0]
     screen.index()
     assert screen.history.top
-    assert screen.history.top[-1] == line._line
+    assert screen.history.top[-1] == line
 
     # b) second index.
     line = screen.buffer[0]
     screen.index()
     assert len(screen.history.top) == 2
-    assert screen.history.top[-1] == line._line
+    assert screen.history.top[-1] == line
 
     # c) rotation.
     for _ in range(screen.history.size * 2):
@@ -62,13 +62,13 @@ def test_reverse_index():
     line = screen.buffer[screen.lines-1]
     screen.reverse_index()
     assert screen.history.bottom
-    assert screen.history.bottom[0] == line._line
+    assert screen.history.bottom[0] == line
 
     # b) second index.
     line = screen.buffer[screen.lines-1]
     screen.reverse_index()
     assert len(screen.history.bottom) == 2
-    assert screen.history.bottom[1] == line._line
+    assert screen.history.bottom[1] == line
 
     # c) rotation.
     for _ in range(screen.history.size * 2):
@@ -656,7 +656,7 @@ def test_ensure_width(monkeypatch):
     stream.feed(ctrl.ESC + "P")
 
     # Inequality because we have an all-empty last line.
-    assert all(len(l) <= 3 for l in screen.history.bottom)
+    assert all(len(l._line) <= 3 for l in screen.history.bottom)
     assert screen.display == [
         "001",  # 18
         "001",  # 19

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -48,9 +48,9 @@ def test_reverse_index():
 
     # Filling the screen with line numbers, so it's easier to
     # track history contents.
-    for idx in range(len(screen.buffer)):
+    for idx in range(screen.lines):
         screen.draw(str(idx))
-        if idx != len(screen.buffer) - 1:
+        if idx != screen.lines - 1:
             screen.linefeed()
 
     assert not screen.history.top
@@ -59,19 +59,19 @@ def test_reverse_index():
     screen.cursor_position()
 
     # a) first index, expecting top history to be updated.
-    line = screen.buffer[-1]
+    line = screen.buffer[screen.lines-1]
     screen.reverse_index()
     assert screen.history.bottom
     assert screen.history.bottom[0] == line
 
     # b) second index.
-    line = screen.buffer[-1]
+    line = screen.buffer[screen.lines-1]
     screen.reverse_index()
     assert len(screen.history.bottom) == 2
     assert screen.history.bottom[1] == line
 
     # c) rotation.
-    for _ in range(len(screen.buffer) ** screen.lines):
+    for _ in range(screen.history.size * 2):
         screen.reverse_index()
 
     assert len(screen.history.bottom) == 50

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -28,13 +28,13 @@ def test_index():
     line = screen.buffer[0]
     screen.index()
     assert screen.history.top
-    assert screen.history.top[-1] == line
+    assert screen.history.top[-1] == line._line
 
     # b) second index.
     line = screen.buffer[0]
     screen.index()
     assert len(screen.history.top) == 2
-    assert screen.history.top[-1] == line
+    assert screen.history.top[-1] == line._line
 
     # c) rotation.
     for _ in range(screen.history.size * 2):
@@ -62,13 +62,13 @@ def test_reverse_index():
     line = screen.buffer[screen.lines-1]
     screen.reverse_index()
     assert screen.history.bottom
-    assert screen.history.bottom[0] == line
+    assert screen.history.bottom[0] == line._line
 
     # b) second index.
     line = screen.buffer[screen.lines-1]
     screen.reverse_index()
     assert len(screen.history.bottom) == 2
-    assert screen.history.bottom[1] == line
+    assert screen.history.bottom[1] == line._line
 
     # c) rotation.
     for _ in range(screen.history.size * 2):

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -1,5 +1,5 @@
 import json
-import os.path
+import os.path, sys
 
 import pytest
 
@@ -8,6 +8,8 @@ import pyte
 
 captured_dir = os.path.join(os.path.dirname(__file__), "captured")
 
+sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
+from asserts import consistency_asserts
 
 @pytest.mark.parametrize("name", [
     "cat-gpl3", "find-etc", "htop", "ls", "mc", "top", "vi"
@@ -23,3 +25,4 @@ def test_input_output(name):
     stream = pyte.ByteStream(screen)
     stream.feed(input)
     assert screen.display == output
+    consistency_asserts(screen)

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -26,3 +26,25 @@ def test_input_output(name):
     stream.feed(input)
     assert screen.display == output
     consistency_asserts(screen)
+
+@pytest.mark.parametrize("name", [
+    "cat-gpl3", "find-etc", "htop", "ls", "mc", "top", "vi"
+])
+def test_input_output_history(name):
+    with open(os.path.join(captured_dir, name + ".input"), "rb") as handle:
+        input = handle.read()
+
+    with open(os.path.join(captured_dir, name + ".output")) as handle:
+        output = json.load(handle)
+
+    screen = pyte.HistoryScreen(80, 24, history=72)
+    stream = pyte.ByteStream(screen)
+    stream.feed(input)
+    screen.prev_page()
+    screen.prev_page()
+    screen.prev_page()
+    screen.next_page()
+    screen.next_page()
+    screen.next_page()
+    assert screen.display == output
+    consistency_asserts(screen)

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -520,11 +520,14 @@ def test_carriage_return():
 
 def test_index():
     screen = update(pyte.Screen(2, 2), ["wo", "ot"], colored=[1])
+    assert (screen.cursor.y, screen.cursor.x) == (0, 0)
+    assert screen.display == ["wo", "ot"]
 
     # a) indexing on a row that isn't the last should just move
     # the cursor down.
     screen.index()
     assert (screen.cursor.y, screen.cursor.x) == (1, 0)
+    assert screen.display == ["wo", "ot"]
     assert tolist(screen) == [
         [Char("w"), Char("o")],
         [Char("o", fg="red"), Char("t", fg="red")]
@@ -534,6 +537,7 @@ def test_index():
     # create a new row at the bottom.
     screen.index()
     assert screen.cursor.y == 1
+    assert screen.display == ["ot", "  "]
     assert tolist(screen) == [
         [Char("o", fg="red"), Char("t", fg="red")],
         [screen.default_char, screen.default_char]
@@ -542,6 +546,8 @@ def test_index():
     # c) same with margins
     screen = update(pyte.Screen(2, 5), ["bo", "sh", "th", "er", "oh"],
                     colored=[1, 2])
+    # note: margins are 0-based inclusive indexes for top and bottom
+    # however, set_margins are 1-based inclusive indexes
     screen.set_margins(2, 4)
     screen.cursor.y = 3
 

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -39,7 +39,7 @@ def update(screen, lines, colored=[], write_spaces=True):
                 # skip, leave the default char in the screen
                 pass
             else:
-                screen._buffer[y].write_data(x, char, 1, style)
+                screen._buffer.line_at(y).write_data(x, char, 1, style)
 
     return screen
 

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -4,10 +4,20 @@ import pytest
 
 import pyte
 from pyte import modes as mo, control as ctrl, graphics as g
-from pyte.screens import Char
+from pyte.screens import Char as _orig_Char, CharStyle
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
 from asserts import consistency_asserts
+
+# Implement the old API of Char so we don't have to change
+# all the tests
+class Char(_orig_Char):
+    def __init__(self, data=" ", fg="default", bg="default", bold=False, italics=False, underscore=False,
+                strikethrough=False, reverse=False, blink=False, width=1):
+        self.data = data
+        self.width = width
+        self.style = CharStyle(fg, bg, bold, italics, underscore, strikethrough, reverse, blink)
+
 
 # Test helpers.
 
@@ -15,13 +25,15 @@ def update(screen, lines, colored=[]):
     """Updates a given screen object with given lines, colors each line
     from ``colored`` in "red" and returns the modified screen.
     """
+    base_style = Char().style
+    red_style = base_style._replace(fg="red")
     for y, line in enumerate(lines):
         for x, char in enumerate(line):
             if y in colored:
-                attrs = {"fg": "red"}
+                style = red_style
             else:
-                attrs = {}
-            screen.buffer[y][x] = Char(data=char, **attrs)
+                style = base_style
+            screen.buffer[y].write_data(x, char, 1, style)
 
     return screen
 

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -1367,6 +1367,7 @@ def test_insert_characters():
     cursor = copy.copy(screen.cursor)
     screen.insert_characters(2)
     assert (screen.cursor.y, screen.cursor.x) == (cursor.y, cursor.x)
+    assert screen.display == ["  s", "is ", "foo", "bar"]
     assert tolist(screen)[0] == [
         screen.default_char,
         screen.default_char,
@@ -1376,11 +1377,13 @@ def test_insert_characters():
     # b) now inserting from the middle of the line
     screen.cursor.y, screen.cursor.x = 2, 1
     screen.insert_characters(1)
+    assert screen.display == ["  s", "is ", "f o", "bar"]
     assert tolist(screen)[2] == [Char("f"), screen.default_char, Char("o")]
 
     # c) inserting more than we have
     screen.cursor.y, screen.cursor.x = 3, 1
     screen.insert_characters(10)
+    assert screen.display == ["  s", "is ", "f o", "b  "]
     assert tolist(screen)[3] == [
         Char("b"), screen.default_char, screen.default_char
     ]

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -2522,3 +2522,83 @@ def test_fuzzy_delete_lines():
         assert original == lines
 
 
+def test_compressed_display():
+    screen = update(pyte.Screen(4, 5), [
+        "    ",
+        " a  ",
+        "    ",
+        "  bb",
+        "    ",
+        ], write_spaces=False)
+
+    assert screen.display == [
+        "    ",
+        " a  ",
+        "    ",
+        "  bb",
+        "    ",
+        ]
+
+    assert screen.compressed_display() == [
+        "    ",
+        " a  ",
+        "    ",
+        "  bb",
+        "    ",
+        ]
+
+    assert screen.compressed_display(lstrip=True) == [
+        "",
+        "a  ",
+        "",
+        "bb",
+        "",
+        ]
+
+    assert screen.compressed_display(rstrip=True) == [
+        "",
+        " a",
+        "",
+        "  bb",
+        "",
+        ]
+
+    assert screen.compressed_display(lstrip=True, rstrip=True) == [
+        "",
+        "a",
+        "",
+        "bb",
+        "",
+        ]
+
+    assert screen.compressed_display(tfilter=True) == [
+        " a  ",
+        "    ",
+        "  bb",
+        "    ",
+        ]
+
+    assert screen.compressed_display(bfilter=True) == [
+        "    ",
+        " a  ",
+        "    ",
+        "  bb",
+        ]
+
+    assert screen.compressed_display(tfilter=True, bfilter=True) == [
+        " a  ",
+        "    ",
+        "  bb",
+        ]
+
+    assert screen.compressed_display(tfilter=True, bfilter=True, rstrip=True) == [
+        " a",
+        "",
+        "  bb",
+        ]
+
+    assert screen.compressed_display(tfilter=True, bfilter=True, lstrip=True) == [
+        "a  ",
+        "",
+        "bb",
+        ]

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -1977,6 +1977,43 @@ def test_erase_in_display():
     ]
     consistency_asserts(screen)
 
+    screen.erase_in_display(3)
+    assert (screen.cursor.y, screen.cursor.x) == (2, 2)
+    assert screen.display == ["     ",
+                              "     ",
+                              "     ",
+                              "     ",
+                              "     "]
+    assert tolist(screen) == [
+        [Char(" ", fg="red")] * 5,
+        [Char(" ", fg="red")] * 5,
+        [Char(" ", fg="red")] * 5,
+        [Char(" ", fg="red")] * 5,
+        [Char(" ", fg="red")] * 5,
+    ]
+    consistency_asserts(screen)
+
+    # erase a clean screen (reset) from the begin to cursor
+    screen.reset()
+    screen.cursor.y = 2
+    screen.cursor.x = 2
+    screen.select_graphic_rendition(31) # red foreground
+
+    screen.erase_in_display(1)
+    assert (screen.cursor.y, screen.cursor.x) == (2, 2)
+    assert screen.display == ["     ",
+                              "     ",
+                              "     ",
+                              "     ",
+                              "     "]
+    assert tolist(screen) == [
+        [Char(" ", fg="red")] * 5,
+        [Char(" ", fg="red")] * 5,
+        [Char(" ", fg="red")] * 3 + [screen.default_char] * 2,
+        [screen.default_char] * 5,
+        [screen.default_char] * 5,
+    ]
+    consistency_asserts(screen)
 
 def test_cursor_up():
     screen = pyte.Screen(10, 10)

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -33,7 +33,9 @@ def update(screen, lines, colored=[]):
                 style = red_style
             else:
                 style = base_style
-            screen.buffer[y].write_data(x, char, 1, style)
+            # Note: this hack is only for testing purposes.
+            # Modifying the screen's buffer is not allowed.
+            screen._buffer[y].write_data(x, char, 1, style)
 
     return screen
 

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -231,6 +231,7 @@ def test_resize():
     screen.set_margins(0, 1)
     assert screen.columns == screen.lines == 2
     assert tolist(screen) == [[screen.default_char, screen.default_char]] * 2
+    consistency_asserts(screen)
 
     screen.resize(3, 3)
     assert screen.columns == screen.lines == 3
@@ -239,10 +240,12 @@ def test_resize():
     ] * 3
     assert mo.DECOM in screen.mode
     assert screen.margins is None
+    consistency_asserts(screen)
 
     screen.resize(2, 2)
     assert screen.columns == screen.lines == 2
     assert tolist(screen) == [[screen.default_char, screen.default_char]] * 2
+    consistency_asserts(screen)
 
     # Quirks:
     # a) if the current display is narrower than the requested size,
@@ -280,6 +283,7 @@ def test_resize_same():
     screen.dirty.clear()
     screen.resize(2, 2)
     assert not screen.dirty
+    consistency_asserts(screen)
 
 
 def test_set_mode():
@@ -341,6 +345,7 @@ def test_draw():
     # ... one` more character -- now we got a linefeed!
     screen.draw("a")
     assert (screen.cursor.y, screen.cursor.x) == (1, 1)
+    consistency_asserts(screen)
 
     # ``DECAWM`` is off.
     screen = pyte.Screen(3, 3)
@@ -404,6 +409,7 @@ def test_draw_width2():
     screen = pyte.Screen(10, 1)
     screen.draw("コンニチハ")
     assert screen.cursor.x == screen.columns
+    consistency_asserts(screen)
 
 
 def test_draw_width2_line_end():
@@ -411,6 +417,7 @@ def test_draw_width2_line_end():
     screen = pyte.Screen(10, 1)
     screen.draw(" コンニチハ")
     assert screen.cursor.x == screen.columns
+    consistency_asserts(screen)
 
 
 @pytest.mark.xfail
@@ -467,11 +474,13 @@ def test_draw_width0_decawm_off():
     screen.reset_mode(mo.DECAWM)
     screen.draw(" コンニチハ")
     assert screen.cursor.x == screen.columns
+    consistency_asserts(screen)
 
     # The following should not advance the cursor.
     screen.draw("\N{ZERO WIDTH SPACE}")
     screen.draw("\u0007")  # DELETE.
     assert screen.cursor.x == screen.columns
+    consistency_asserts(screen)
 
 
 def test_draw_cp437():
@@ -520,6 +529,7 @@ def test_carriage_return():
     screen.carriage_return()
 
     assert screen.cursor.x == 0
+    consistency_asserts(screen)
 
 
 def test_index():
@@ -536,6 +546,7 @@ def test_index():
         [Char("w"), Char("o")],
         [Char("o", fg="red"), Char("t", fg="red")]
     ]
+    consistency_asserts(screen)
 
     # b) indexing on the last row should push everything up and
     # create a new row at the bottom.
@@ -546,6 +557,7 @@ def test_index():
         [Char("o", fg="red"), Char("t", fg="red")],
         [screen.default_char, screen.default_char]
     ]
+    consistency_asserts(screen)
 
     # c) same with margins
     screen = update(pyte.Screen(2, 5), ["bo", "sh", "th", "er", "oh"],
@@ -645,6 +657,7 @@ def test_index_sparse():
         [screen.default_char] * 5,
         [Char("x")] + [screen.default_char] * 3 + [Char("z")],
     ]
+    consistency_asserts(screen)
 
     # b) indexing on the last row should push everything up and
     # create a new row at the bottom.
@@ -667,6 +680,7 @@ def test_index_sparse():
         [Char("x")] + [screen.default_char] * 3 + [Char("z")],
         [screen.default_char] * 5,
     ]
+    consistency_asserts(screen)
 
     # again
     screen.index()
@@ -685,6 +699,7 @@ def test_index_sparse():
         [screen.default_char] * 5,
         [screen.default_char] * 5,
     ]
+    consistency_asserts(screen)
 
     # leave the screen cleared
     screen.index()
@@ -705,6 +720,7 @@ def test_index_sparse():
         [screen.default_char] * 5,
         [screen.default_char] * 5,
     ]
+    consistency_asserts(screen)
 
 
 def test_reverse_index():
@@ -718,6 +734,7 @@ def test_reverse_index():
         [screen.default_char, screen.default_char],
         [Char("w", fg="red"), Char("o", fg="red")]
     ]
+    consistency_asserts(screen)
 
     # b) once again ...
     screen.reverse_index()
@@ -726,6 +743,7 @@ def test_reverse_index():
         [screen.default_char, screen.default_char],
         [screen.default_char, screen.default_char],
     ]
+    consistency_asserts(screen)
 
     # c) same with margins
     screen = update(pyte.Screen(2, 5), ["bo", "sh", "th", "er", "oh"],
@@ -804,6 +822,7 @@ def test_reverse_index_sparse():
             "     ",
             "x   z",
             ]
+    consistency_asserts(screen)
 
     # a) reverse indexing on the first row should push rows down
     # and create a new row at the top.
@@ -823,6 +842,7 @@ def test_reverse_index_sparse():
         [screen.default_char, Char("o", fg="red"), screen.default_char, Char("t", fg="red"), screen.default_char],
         [screen.default_char] * 5,
     ]
+    consistency_asserts(screen)
 
     # again
     screen.reverse_index()
@@ -841,6 +861,7 @@ def test_reverse_index_sparse():
         [screen.default_char] * 5,
         [screen.default_char, Char("o", fg="red"), screen.default_char, Char("t", fg="red"), screen.default_char],
     ]
+    consistency_asserts(screen)
 
     # again
     screen.reverse_index()
@@ -859,6 +880,7 @@ def test_reverse_index_sparse():
         [Char("w"), Char("o"),] + [screen.default_char] * 3,
         [screen.default_char] * 5,
     ]
+    consistency_asserts(screen)
 
     # leave the screen cleared
     screen.reverse_index()
@@ -878,6 +900,7 @@ def test_reverse_index_sparse():
         [screen.default_char] * 5,
         [screen.default_char] * 5,
     ]
+    consistency_asserts(screen)
 
 def test_linefeed():
     screen = update(pyte.Screen(2, 2), ["bo", "sh"], [None, None])
@@ -888,12 +911,14 @@ def test_linefeed():
     screen.cursor.x, screen.cursor.y = 1, 0
     screen.linefeed()
     assert (screen.cursor.y, screen.cursor.x) == (1, 0)
+    consistency_asserts(screen)
 
     # b) LNM off.
     screen.reset_mode(mo.LNM)
     screen.cursor.x, screen.cursor.y = 1, 0
     screen.linefeed()
     assert (screen.cursor.y, screen.cursor.x) == (1, 1)
+    consistency_asserts(screen)
 
 
 def test_linefeed_margins():
@@ -902,8 +927,10 @@ def test_linefeed_margins():
     screen.set_margins(3, 27)
     screen.cursor_position()
     assert (screen.cursor.y, screen.cursor.x) == (0, 0)
+    consistency_asserts(screen)
     screen.linefeed()
     assert (screen.cursor.y, screen.cursor.x) == (1, 0)
+    consistency_asserts(screen)
 
 
 def test_tabstops():
@@ -930,6 +957,7 @@ def test_tabstops():
     assert screen.cursor.x == 9
     screen.tab()
     assert screen.cursor.x == 9
+    consistency_asserts(screen)
 
 
 def test_clear_tabstops():
@@ -944,6 +972,7 @@ def test_clear_tabstops():
     screen.clear_tab_stop()
 
     assert screen.tabstops == set([1])
+    consistency_asserts(screen)
 
     screen.set_tab_stop()
     screen.clear_tab_stop(0)
@@ -957,6 +986,7 @@ def test_clear_tabstops():
     screen.clear_tab_stop(3)
 
     assert not screen.tabstops
+    consistency_asserts(screen)
 
 
 def test_backspace():
@@ -967,6 +997,7 @@ def test_backspace():
     screen.cursor.x = 1
     screen.backspace()
     assert screen.cursor.x == 0
+    consistency_asserts(screen)
 
 
 def test_save_cursor():
@@ -1008,6 +1039,7 @@ def test_save_cursor():
 
     assert screen.cursor.attrs != screen.default_char
     assert screen.cursor.attrs == Char(" ", underscore=True)
+    consistency_asserts(screen)
 
 
 def test_restore_cursor_with_none_saved():
@@ -1031,6 +1063,7 @@ def test_restore_cursor_out_of_bounds():
     screen.restore_cursor()
 
     assert (screen.cursor.y, screen.cursor.x) == (2, 2)
+    consistency_asserts(screen)
 
     # b) origin mode is on.
     screen.resize(10, 10)
@@ -1043,6 +1076,7 @@ def test_restore_cursor_out_of_bounds():
     screen.restore_cursor()
 
     assert (screen.cursor.y, screen.cursor.x) == (2, 4)
+    consistency_asserts(screen)
 
 
 def test_insert_lines():
@@ -1373,12 +1407,14 @@ def test_insert_characters():
         screen.default_char,
         Char("s", fg="red")
     ]
+    consistency_asserts(screen)
 
     # b) now inserting from the middle of the line
     screen.cursor.y, screen.cursor.x = 2, 1
     screen.insert_characters(1)
     assert screen.display == ["  s", "is ", "f o", "bar"]
     assert tolist(screen)[2] == [Char("f"), screen.default_char, Char("o")]
+    consistency_asserts(screen)
 
     # c) inserting more than we have
     screen.cursor.y, screen.cursor.x = 3, 1
@@ -1389,6 +1425,7 @@ def test_insert_characters():
     ]
 
     assert screen.display == ["  s", "is ", "f o", "b  "]
+    consistency_asserts(screen)
 
     # insert 1 at the begin of the previously edited line
     screen.cursor.y, screen.cursor.x = 3, 0
@@ -1396,6 +1433,7 @@ def test_insert_characters():
     assert tolist(screen)[3] == [
         screen.default_char, Char("b"), screen.default_char,
     ]
+    consistency_asserts(screen)
 
     # insert before the end of the line
     screen.cursor.y, screen.cursor.x = 3, 2
@@ -1403,6 +1441,7 @@ def test_insert_characters():
     assert tolist(screen)[3] == [
         screen.default_char, Char("b"), screen.default_char,
     ]
+    consistency_asserts(screen)
 
     # insert enough to push outside the screen the remaining char
     screen.cursor.y, screen.cursor.x = 3, 0
@@ -1412,6 +1451,7 @@ def test_insert_characters():
     ]
 
     assert screen.display == ["  s", "is ", "f o", "   "]
+    consistency_asserts(screen)
 
     # d) 0 is 1
     screen = update(pyte.Screen(3, 3), ["sam", "is ", "foo"], colored=[0])
@@ -1422,6 +1462,7 @@ def test_insert_characters():
         screen.default_char,
         Char("s", fg="red"), Char("a", fg="red")
     ]
+    consistency_asserts(screen)
 
     screen = update(pyte.Screen(3, 3), ["sam", "is ", "foo"], colored=[0])
     screen.cursor_position()
@@ -1430,6 +1471,7 @@ def test_insert_characters():
         screen.default_char,
         Char("s", fg="red"), Char("a", fg="red")
     ]
+    consistency_asserts(screen)
 
 
     # ! extreme cases.
@@ -2084,6 +2126,7 @@ def test_cursor_back_last_column():
 
     screen.cursor_back(5)
     assert screen.cursor.x == (screen.columns - 1) - 5
+    consistency_asserts(screen)
 
 
 def test_cursor_forward():

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -1385,6 +1385,31 @@ def test_insert_characters():
         Char("b"), screen.default_char, screen.default_char
     ]
 
+    assert screen.display == ["  s", "is ", "f o", "b  "]
+
+    # insert 1 at the begin of the previously edited line
+    screen.cursor.y, screen.cursor.x = 3, 0
+    screen.insert_characters(1)
+    assert tolist(screen)[3] == [
+        screen.default_char, Char("b"), screen.default_char,
+    ]
+
+    # insert before the end of the line
+    screen.cursor.y, screen.cursor.x = 3, 2
+    screen.insert_characters(1)
+    assert tolist(screen)[3] == [
+        screen.default_char, Char("b"), screen.default_char,
+    ]
+
+    # insert enough to push outside the screen the remaining char
+    screen.cursor.y, screen.cursor.x = 3, 0
+    screen.insert_characters(2)
+    assert tolist(screen)[3] == [
+        screen.default_char, screen.default_char, screen.default_char,
+    ]
+
+    assert screen.display == ["  s", "is ", "f o", "   "]
+
     # d) 0 is 1
     screen = update(pyte.Screen(3, 3), ["sam", "is ", "foo"], colored=[0])
 
@@ -1403,6 +1428,46 @@ def test_insert_characters():
         Char("s", fg="red"), Char("a", fg="red")
     ]
 
+
+    # ! extreme cases.
+    screen = update(pyte.Screen(5, 1), ["12345"], colored=[0])
+    screen.cursor.x = 1
+    screen.insert_characters(3)
+    assert (screen.cursor.y, screen.cursor.x) == (0, 1)
+    assert screen.display == ["1   2"]
+    assert tolist(screen)[0] == [
+        Char("1", fg="red"),
+        screen.default_char,
+        screen.default_char,
+        screen.default_char,
+        Char("2", fg="red"),
+    ]
+    consistency_asserts(screen)
+
+    screen.insert_characters(1)
+    assert (screen.cursor.y, screen.cursor.x) == (0, 1)
+    assert screen.display == ["1    "]
+    assert tolist(screen)[0] == [
+        Char("1", fg="red"),
+        screen.default_char,
+        screen.default_char,
+        screen.default_char,
+        screen.default_char,
+    ]
+    consistency_asserts(screen)
+
+    screen.cursor.x = 0
+    screen.insert_characters(5)
+    assert (screen.cursor.y, screen.cursor.x) == (0, 0)
+    assert screen.display == ["     "]
+    assert tolist(screen)[0] == [
+        screen.default_char,
+        screen.default_char,
+        screen.default_char,
+        screen.default_char,
+        screen.default_char,
+    ]
+    consistency_asserts(screen)
 
 def test_delete_characters():
     screen = update(pyte.Screen(3, 3), ["sam", "is ", "foo"], colored=[0])
@@ -1425,6 +1490,20 @@ def test_delete_characters():
     screen.delete_characters(0)
     assert (screen.cursor.y, screen.cursor.x) == (1, 1)
     assert screen.display == ["m  ", "i  ", "fo "]
+    consistency_asserts(screen)
+
+    # try to erase spaces
+    screen.cursor.y, screen.cursor.x = 1, 1
+    screen.delete_characters(0)
+    assert (screen.cursor.y, screen.cursor.x) == (1, 1)
+    assert screen.display == ["m  ", "i  ", "fo "]
+    consistency_asserts(screen)
+
+    # try to erase a whole line
+    screen.cursor.y, screen.cursor.x = 1, 0
+    screen.delete_characters(0)
+    assert (screen.cursor.y, screen.cursor.x) == (1, 0)
+    assert screen.display == ["m  ", "   ", "fo "]
     consistency_asserts(screen)
 
     # ! extreme cases.
@@ -1469,6 +1548,18 @@ def test_delete_characters():
     ]
     consistency_asserts(screen)
 
+    screen.delete_characters(2)
+    assert (screen.cursor.y, screen.cursor.x) == (0, 0)
+    assert screen.display == ["     "]
+    assert tolist(screen)[0] == [
+        screen.default_char,
+        screen.default_char,
+        screen.default_char,
+        screen.default_char,
+        screen.default_char
+    ]
+    consistency_asserts(screen)
+
 
 def test_erase_character():
     screen = update(pyte.Screen(3, 3), ["sam", "is ", "foo"], colored=[0])
@@ -1493,6 +1584,20 @@ def test_erase_character():
     screen.erase_characters(0)
     assert (screen.cursor.y, screen.cursor.x) == (1, 1)
     assert screen.display == ["  m", "i  ", "fo "]
+    consistency_asserts(screen)
+
+    # erase the same erased char as before
+    screen.cursor.y, screen.cursor.x = 1, 1
+    screen.erase_characters(0)
+    assert (screen.cursor.y, screen.cursor.x) == (1, 1)
+    assert screen.display == ["  m", "i  ", "fo "]
+    consistency_asserts(screen)
+
+    # erase the whole line
+    screen.cursor.y, screen.cursor.x = 1, 0
+    screen.erase_characters(0)
+    assert (screen.cursor.y, screen.cursor.x) == (1, 0)
+    assert screen.display == ["  m", "   ", "fo "]
     consistency_asserts(screen)
 
     # ! extreme cases.
@@ -1537,6 +1642,18 @@ def test_erase_character():
     ]
     consistency_asserts(screen)
 
+    screen.cursor.x = 2
+    screen.erase_characters(4)
+    assert (screen.cursor.y, screen.cursor.x) == (0, 2)
+    assert screen.display == ["     "]
+    assert tolist(screen)[0] == [
+        screen.default_char,
+        screen.default_char,
+        screen.default_char,
+        screen.default_char,
+        screen.default_char,
+    ]
+    consistency_asserts(screen)
 
 def test_erase_in_line():
     screen = update(pyte.Screen(5, 5),

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -1,4 +1,4 @@
-import copy
+import copy, sys, os
 
 import pytest
 
@@ -6,6 +6,8 @@ import pyte
 from pyte import modes as mo, control as ctrl, graphics as g
 from pyte.screens import Char
 
+sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
+from asserts import consistency_asserts
 
 # Test helpers.
 
@@ -230,12 +232,14 @@ def test_resize():
     screen = update(pyte.Screen(2, 2), ["bo", "sh"], [None, None])
     screen.resize(2, 3)
     assert screen.display == ["bo ", "sh "]
+    consistency_asserts(screen)
 
     # b) if the current display is wider than the requested size,
     #    columns should be removed from the right...
     screen = update(pyte.Screen(2, 2), ["bo", "sh"], [None, None])
     screen.resize(2, 1)
     assert screen.display == ["b", "s"]
+    consistency_asserts(screen)
 
     # c) if the current display is shorter than the requested
     #    size, new rows should be added on the bottom.
@@ -243,12 +247,14 @@ def test_resize():
     screen.resize(3, 2)
 
     assert screen.display == ["bo", "sh", "  "]
+    consistency_asserts(screen)
 
     # d) if the current display is taller than the requested
     #    size, rows should be removed from the top.
     screen = update(pyte.Screen(2, 2), ["bo", "sh"], [None, None])
     screen.resize(1, 2)
     assert screen.display == ["sh"]
+    consistency_asserts(screen)
 
 
 def test_resize_same():
@@ -312,6 +318,7 @@ def test_draw():
 
     assert screen.display == ["abc", "   ", "   "]
     assert (screen.cursor.y, screen.cursor.x) == (0, 3)
+    consistency_asserts(screen)
 
     # ... one` more character -- now we got a linefeed!
     screen.draw("a")
@@ -326,11 +333,13 @@ def test_draw():
 
     assert screen.display == ["abc", "   ", "   "]
     assert (screen.cursor.y, screen.cursor.x) == (0, 3)
+    consistency_asserts(screen)
 
     # No linefeed is issued on the end of the line ...
     screen.draw("a")
     assert screen.display == ["aba", "   ", "   "]
     assert (screen.cursor.y, screen.cursor.x) == (0, 3)
+    consistency_asserts(screen)
 
     # ``IRM`` mode is on, expecting new characters to move the old ones
     # instead of replacing them.
@@ -338,10 +347,12 @@ def test_draw():
     screen.cursor_position()
     screen.draw("x")
     assert screen.display == ["xab", "   ", "   "]
+    consistency_asserts(screen)
 
     screen.cursor_position()
     screen.draw("y")
     assert screen.display == ["yxa", "   ", "   "]
+    consistency_asserts(screen)
 
 
 def test_draw_russian():
@@ -350,6 +361,7 @@ def test_draw_russian():
     stream = pyte.Stream(screen)
     stream.feed("Нерусский текст")
     assert screen.display == ["Нерусский текст     "]
+    consistency_asserts(screen)
 
 
 def test_draw_multiple_chars():
@@ -357,6 +369,7 @@ def test_draw_multiple_chars():
     screen.draw("foobar")
     assert screen.cursor.x == 6
     assert screen.display == ["foobar    "]
+    consistency_asserts(screen)
 
 
 def test_draw_utf8():
@@ -365,6 +378,7 @@ def test_draw_utf8():
     stream = pyte.ByteStream(screen)
     stream.feed(b"\xE2\x80\x9D")
     assert screen.display == ["”"]
+    consistency_asserts(screen)
 
 
 def test_draw_width2():
@@ -387,12 +401,14 @@ def test_draw_width2_irm():
     screen.draw("コ")
     assert screen.display == ["コ"]
     assert tolist(screen) == [[Char("コ"), Char(" ")]]
+    consistency_asserts(screen)
 
     # Overwrite the stub part of a width 2 character.
     screen.set_mode(mo.IRM)
     screen.cursor_to_column(screen.columns)
     screen.draw("x")
     assert screen.display == [" x"]
+    consistency_asserts(screen)
 
 
 def test_draw_width0_combining():
@@ -401,17 +417,20 @@ def test_draw_width0_combining():
     # a) no prev. character
     screen.draw("\N{COMBINING DIAERESIS}")
     assert screen.display == ["    ", "    "]
+    consistency_asserts(screen)
 
     screen.draw("bad")
 
     # b) prev. character is on the same line
     screen.draw("\N{COMBINING DIAERESIS}")
     assert screen.display == ["bad̈ ", "    "]
+    consistency_asserts(screen)
 
     # c) prev. character is on the prev. line
     screen.draw("!")
     screen.draw("\N{COMBINING DIAERESIS}")
     assert screen.display == ["bad̈!̈", "    "]
+    consistency_asserts(screen)
 
 
 def test_draw_width0_irm():
@@ -422,6 +441,7 @@ def test_draw_width0_irm():
     screen.draw("\N{ZERO WIDTH SPACE}")
     screen.draw("\u0007")  # DELETE.
     assert screen.display == [" " * screen.columns]
+    consistency_asserts(screen)
 
 
 def test_draw_width0_decawm_off():
@@ -446,6 +466,7 @@ def test_draw_cp437():
     stream.feed("α ± ε".encode("cp437"))
 
     assert screen.display == ["α ± ε"]
+    consistency_asserts(screen)
 
 
 def test_draw_with_carriage_return():
@@ -465,12 +486,14 @@ tpd startssl"""
         "pcrm sem ;ps aux|grep -P 'httpd|fcgi'|grep -v grep",
         "}'|xargs kill -9;/etc/init.d/httpd startssl       "
     ]
+    consistency_asserts(screen)
 
 
 def test_display_wcwidth():
     screen = pyte.Screen(10, 1)
     screen.draw("コンニチハ")
     assert screen.display == ["コンニチハ"]
+    consistency_asserts(screen)
 
 
 def test_carriage_return():
@@ -519,6 +542,7 @@ def test_index():
         [screen.default_char, screen.default_char],
         [Char("o"), Char("h")],
     ]
+    consistency_asserts(screen)
 
     # ... and again ...
     screen.index()
@@ -531,6 +555,7 @@ def test_index():
         [screen.default_char, screen.default_char],
         [Char("o"), Char("h")],
     ]
+    consistency_asserts(screen)
 
     # ... and again ...
     screen.index()
@@ -543,6 +568,7 @@ def test_index():
         [screen.default_char, screen.default_char],
         [Char("o"), Char("h")],
     ]
+    consistency_asserts(screen)
 
     # look, nothing changes!
     screen.index()
@@ -555,6 +581,7 @@ def test_index():
         [screen.default_char, screen.default_char],
         [Char("o"), Char("h")],
     ]
+    consistency_asserts(screen)
 
 
 def test_reverse_index():
@@ -594,6 +621,7 @@ def test_reverse_index():
         [Char("t", fg="red"), Char("h", fg="red")],
         [Char("o"), Char("h")],
     ]
+    consistency_asserts(screen)
 
     # ... and again ...
     screen.reverse_index()
@@ -606,6 +634,7 @@ def test_reverse_index():
         [Char("s"), Char("h")],
         [Char("o"), Char("h")],
     ]
+    consistency_asserts(screen)
 
     # ... and again ...
     screen.reverse_index()
@@ -618,6 +647,7 @@ def test_reverse_index():
         [screen.default_char, screen.default_char],
         [Char("o"), Char("h")],
     ]
+    consistency_asserts(screen)
 
     # look, nothing changes!
     screen.reverse_index()
@@ -630,6 +660,7 @@ def test_reverse_index():
         [screen.default_char, screen.default_char],
         [Char("o"), Char("h")],
     ]
+    consistency_asserts(screen)
 
 
 def test_linefeed():
@@ -810,6 +841,7 @@ def test_insert_lines():
         [Char("s"), Char("a"), Char("m")],
         [Char("i", fg="red"), Char("s", fg="red"), Char(" ", fg="red")],
     ]
+    consistency_asserts(screen)
 
     screen = update(pyte.Screen(3, 3), ["sam", "is ", "foo"], colored=[1])
     screen.insert_lines(2)
@@ -821,6 +853,7 @@ def test_insert_lines():
         [screen.default_char] * 3,
         [Char("s"), Char("a"), Char("m")]
     ]
+    consistency_asserts(screen)
 
     # b) with margins
     screen = update(pyte.Screen(3, 5), ["sam", "is ", "foo", "bar", "baz"],
@@ -838,6 +871,7 @@ def test_insert_lines():
         [Char("f", fg="red"), Char("o", fg="red"), Char("o", fg="red")],
         [Char("b"), Char("a"), Char("z")],
     ]
+    consistency_asserts(screen)
 
     screen = update(pyte.Screen(3, 5), ["sam", "is ", "foo", "bar", "baz"],
                     colored=[2, 3])
@@ -854,6 +888,7 @@ def test_insert_lines():
         [Char("b", fg="red"), Char("a", fg="red"), Char("r", fg="red")],
         [Char("b"), Char("a"), Char("z")],
     ]
+    consistency_asserts(screen)
 
     screen.insert_lines(2)
     assert (screen.cursor.y, screen.cursor.x) == (1, 0)
@@ -865,6 +900,7 @@ def test_insert_lines():
         [Char("b", fg="red"), Char("a", fg="red"), Char("r", fg="red")],
         [Char("b"), Char("a"), Char("z")],
     ]
+    consistency_asserts(screen)
 
     # c) with margins -- trying to insert more than we have available
     screen = update(pyte.Screen(3, 5), ["sam", "is ", "foo", "bar", "baz"],
@@ -882,6 +918,7 @@ def test_insert_lines():
         [screen.default_char] * 3,
         [Char("b"), Char("a"), Char("z")],
     ]
+    consistency_asserts(screen)
 
     # d) with margins -- trying to insert outside scroll boundaries;
     #    expecting nothing to change
@@ -899,6 +936,7 @@ def test_insert_lines():
         [Char("b", fg="red"), Char("a", fg="red"), Char("r", fg="red")],
         [Char("b"), Char("a"), Char("z")],
     ]
+    consistency_asserts(screen)
 
 
 def test_delete_lines():
@@ -913,6 +951,7 @@ def test_delete_lines():
         [Char("f"), Char("o"), Char("o")],
         [screen.default_char] * 3,
     ]
+    consistency_asserts(screen)
 
     screen.delete_lines(0)
 
@@ -923,6 +962,7 @@ def test_delete_lines():
         [screen.default_char] * 3,
         [screen.default_char] * 3,
     ]
+    consistency_asserts(screen)
 
     # b) with margins
     screen = update(pyte.Screen(3, 5), ["sam", "is ", "foo", "bar", "baz"],
@@ -940,6 +980,7 @@ def test_delete_lines():
         [screen.default_char] * 3,
         [Char("b"), Char("a"), Char("z")],
     ]
+    consistency_asserts(screen)
 
     screen = update(pyte.Screen(3, 5), ["sam", "is ", "foo", "bar", "baz"],
                     colored=[2, 3])
@@ -956,6 +997,7 @@ def test_delete_lines():
         [screen.default_char] * 3,
         [Char("b"), Char("a"), Char("z")],
     ]
+    consistency_asserts(screen)
 
     # c) with margins -- trying to delete  more than we have available
     screen = update(pyte.Screen(3, 5),
@@ -978,6 +1020,7 @@ def test_delete_lines():
         [screen.default_char] * 3,
         [Char("b"), Char("a"), Char("z")],
     ]
+    consistency_asserts(screen)
 
     # d) with margins -- trying to delete outside scroll boundaries;
     #    expecting nothing to change
@@ -996,6 +1039,7 @@ def test_delete_lines():
         [Char("b", fg="red"), Char("a", fg="red"), Char("r", fg="red")],
         [Char("b"), Char("a"), Char("z")],
     ]
+    consistency_asserts(screen)
 
 
 def test_insert_characters():
@@ -1052,16 +1096,19 @@ def test_delete_characters():
         Char("m", fg="red"),
         screen.default_char, screen.default_char
     ]
+    consistency_asserts(screen)
 
     screen.cursor.y, screen.cursor.x = 2, 2
     screen.delete_characters()
     assert (screen.cursor.y, screen.cursor.x) == (2, 2)
     assert screen.display == ["m  ", "is ", "fo "]
+    consistency_asserts(screen)
 
     screen.cursor.y, screen.cursor.x = 1, 1
     screen.delete_characters(0)
     assert (screen.cursor.y, screen.cursor.x) == (1, 1)
     assert screen.display == ["m  ", "i  ", "fo "]
+    consistency_asserts(screen)
 
     # ! extreme cases.
     screen = update(pyte.Screen(5, 1), ["12345"], colored=[0])
@@ -1076,6 +1123,7 @@ def test_delete_characters():
         screen.default_char,
         screen.default_char
     ]
+    consistency_asserts(screen)
 
     screen = update(pyte.Screen(5, 1), ["12345"], colored=[0])
     screen.cursor.x = 2
@@ -1089,6 +1137,7 @@ def test_delete_characters():
         screen.default_char,
         screen.default_char
     ]
+    consistency_asserts(screen)
 
     screen = update(pyte.Screen(5, 1), ["12345"], colored=[0])
     screen.delete_characters(4)
@@ -1101,6 +1150,7 @@ def test_delete_characters():
         screen.default_char,
         screen.default_char
     ]
+    consistency_asserts(screen)
 
 
 def test_erase_character():
@@ -1114,16 +1164,19 @@ def test_erase_character():
         screen.default_char,
         Char("m", fg="red")
     ]
+    consistency_asserts(screen)
 
     screen.cursor.y, screen.cursor.x = 2, 2
     screen.erase_characters()
     assert (screen.cursor.y, screen.cursor.x) == (2, 2)
     assert screen.display == ["  m", "is ", "fo "]
+    consistency_asserts(screen)
 
     screen.cursor.y, screen.cursor.x = 1, 1
     screen.erase_characters(0)
     assert (screen.cursor.y, screen.cursor.x) == (1, 1)
     assert screen.display == ["  m", "i  ", "fo "]
+    consistency_asserts(screen)
 
     # ! extreme cases.
     screen = update(pyte.Screen(5, 1), ["12345"], colored=[0])
@@ -1138,6 +1191,7 @@ def test_erase_character():
         screen.default_char,
         Char("5", "red")
     ]
+    consistency_asserts(screen)
 
     screen = update(pyte.Screen(5, 1), ["12345"], colored=[0])
     screen.cursor.x = 2
@@ -1151,6 +1205,7 @@ def test_erase_character():
         screen.default_char,
         screen.default_char
     ]
+    consistency_asserts(screen)
 
     screen = update(pyte.Screen(5, 1), ["12345"], colored=[0])
     screen.erase_characters(4)
@@ -1163,6 +1218,7 @@ def test_erase_character():
         screen.default_char,
         Char("5", fg="red")
     ]
+    consistency_asserts(screen)
 
 
 def test_erase_in_line():
@@ -1189,6 +1245,7 @@ def test_erase_in_line():
         screen.default_char,
         screen.default_char
     ]
+    consistency_asserts(screen)
 
     # b) erase from the beginning of the line to the cursor
     screen = update(screen,
@@ -1211,6 +1268,7 @@ def test_erase_in_line():
         Char(" ", fg="red"),
         Char("i", fg="red")
     ]
+    consistency_asserts(screen)
 
     # c) erase the entire line
     screen = update(screen,
@@ -1227,6 +1285,7 @@ def test_erase_in_line():
                               "re yo",
                               "u?   "]
     assert tolist(screen)[0] == [screen.default_char] * 5
+    consistency_asserts(screen)
 
 
 def test_erase_in_display():
@@ -1256,6 +1315,7 @@ def test_erase_in_display():
         [screen.default_char] * 5,
         [screen.default_char] * 5
     ]
+    consistency_asserts(screen)
 
     # b) erase from the beginning of the display to the cursor,
     #    including it
@@ -1281,6 +1341,7 @@ def test_erase_in_display():
          Char(" ", fg="red"),
          Char("a", fg="red")],
     ]
+    consistency_asserts(screen)
 
     # c) erase the while display
     screen.erase_in_display(2)
@@ -1291,6 +1352,7 @@ def test_erase_in_display():
                               "     ",
                               "     "]
     assert tolist(screen) == [[screen.default_char] * 5] * 5
+    consistency_asserts(screen)
 
     # d) erase with private mode
     screen = update(pyte.Screen(5, 5),
@@ -1305,6 +1367,7 @@ def test_erase_in_display():
                               "     ",
                               "     ",
                               "     "]
+    consistency_asserts(screen)
 
     # e) erase with extra args
     screen = update(pyte.Screen(5, 5),
@@ -1320,6 +1383,7 @@ def test_erase_in_display():
                               "     ",
                               "     ",
                               "     "]
+    consistency_asserts(screen)
 
     # f) erase with extra args and private
     screen = update(pyte.Screen(5, 5),
@@ -1334,6 +1398,7 @@ def test_erase_in_display():
                               "     ",
                               "     ",
                               "     "]
+    consistency_asserts(screen)
 
 
 def test_cursor_up():
@@ -1462,6 +1527,7 @@ def test_unicode():
 
     stream.feed("тест".encode("utf-8"))
     assert screen.display == ["тест", "    "]
+    consistency_asserts(screen)
 
 
 def test_alignment_display():
@@ -1477,6 +1543,7 @@ def test_alignment_display():
                               "b    ",
                               "     ",
                               "     "]
+    consistency_asserts(screen)
 
     screen.alignment_display()
 
@@ -1485,6 +1552,7 @@ def test_alignment_display():
                               "EEEEE",
                               "EEEEE",
                               "EEEEE"]
+    consistency_asserts(screen)
 
 
 def test_set_margins():

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -1059,6 +1059,37 @@ def test_insert_lines():
     ]
     consistency_asserts(screen)
 
+
+    screen.insert_lines(1)
+    assert (screen.cursor.y, screen.cursor.x) == (0, 0)
+    assert screen.display == ["   ", "   ", "sam"]
+    assert tolist(screen) == [
+        [screen.default_char] * 3,
+        [screen.default_char] * 3,
+        [Char("s"), Char("a"), Char("m")]
+    ]
+    consistency_asserts(screen)
+
+    screen.insert_lines(1)
+    assert (screen.cursor.y, screen.cursor.x) == (0, 0)
+    assert screen.display == ["   ", "   ", "   "]
+    assert tolist(screen) == [
+        [screen.default_char] * 3,
+        [screen.default_char] * 3,
+        [screen.default_char] * 3,
+    ]
+    consistency_asserts(screen)
+
+    screen.insert_lines(1)
+    assert (screen.cursor.y, screen.cursor.x) == (0, 0)
+    assert screen.display == ["   ", "   ", "   "]
+    assert tolist(screen) == [
+        [screen.default_char] * 3,
+        [screen.default_char] * 3,
+        [screen.default_char] * 3,
+    ]
+    consistency_asserts(screen)
+
     screen = update(pyte.Screen(3, 3), ["sam", "is ", "foo"], colored=[1])
     screen.insert_lines(2)
 
@@ -1068,6 +1099,54 @@ def test_insert_lines():
         [screen.default_char] * 3,
         [screen.default_char] * 3,
         [Char("s"), Char("a"), Char("m")]
+    ]
+    consistency_asserts(screen)
+
+    screen = update(pyte.Screen(3, 5), [
+        "sam",
+        "",     # an empty string will be interpreted as a full empty line
+        "foo",
+        "bar",
+        "baz"
+        ],
+        colored=[2, 3])
+
+    screen.insert_lines(2)
+
+    assert (screen.cursor.y, screen.cursor.x) == (0, 0)
+    assert screen.display == ["   ", "   ", "sam", "   ", "foo"]
+    assert tolist(screen) == [
+        [screen.default_char] * 3,
+        [screen.default_char] * 3,
+        [Char("s"), Char("a"), Char("m")],
+        [screen.default_char] * 3,
+        [Char("f", fg="red"), Char("o", fg="red"), Char("o", fg="red")],
+    ]
+    consistency_asserts(screen)
+
+    screen.insert_lines(1)
+
+    assert (screen.cursor.y, screen.cursor.x) == (0, 0)
+    assert screen.display == ["   ", "   ", "   ", "sam", "   "]
+    assert tolist(screen) == [
+        [screen.default_char] * 3,
+        [screen.default_char] * 3,
+        [screen.default_char] * 3,
+        [Char("s"), Char("a"), Char("m")],
+        [screen.default_char] * 3,
+    ]
+    consistency_asserts(screen)
+
+    screen.insert_lines(1)
+
+    assert (screen.cursor.y, screen.cursor.x) == (0, 0)
+    assert screen.display == ["   ", "   ", "   ", "   ", "sam"]
+    assert tolist(screen) == [
+        [screen.default_char] * 3,
+        [screen.default_char] * 3,
+        [screen.default_char] * 3,
+        [screen.default_char] * 3,
+        [Char("s"), Char("a"), Char("m")],
     ]
     consistency_asserts(screen)
 
@@ -1175,6 +1254,28 @@ def test_delete_lines():
     assert screen.display == ["foo", "   ", "   "]
     assert tolist(screen) == [
         [Char("f"), Char("o"), Char("o")],
+        [screen.default_char] * 3,
+        [screen.default_char] * 3,
+    ]
+    consistency_asserts(screen)
+
+    screen.delete_lines(0)
+
+    assert (screen.cursor.y, screen.cursor.x) == (0, 0)
+    assert screen.display == ["   ", "   ", "   "]
+    assert tolist(screen) == [
+        [screen.default_char] * 3,
+        [screen.default_char] * 3,
+        [screen.default_char] * 3,
+    ]
+    consistency_asserts(screen)
+
+    screen.delete_lines(0)
+
+    assert (screen.cursor.y, screen.cursor.x) == (0, 0)
+    assert screen.display == ["   ", "   ", "   "]
+    assert tolist(screen) == [
+        [screen.default_char] * 3,
         [screen.default_char] * 3,
         [screen.default_char] * 3,
     ]

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -227,8 +227,10 @@ def test_attributes_reset():
 
 def test_resize():
     screen = pyte.Screen(2, 2)
+    assert screen.margins == (0, 1)
     screen.set_mode(mo.DECOM)
     screen.set_margins(0, 1)
+    assert screen.margins == (0, 1)
     assert screen.columns == screen.lines == 2
     assert tolist(screen) == [[screen.default_char, screen.default_char]] * 2
     consistency_asserts(screen)
@@ -239,7 +241,7 @@ def test_resize():
         [screen.default_char, screen.default_char, screen.default_char]
     ] * 3
     assert mo.DECOM in screen.mode
-    assert screen.margins is None
+    assert screen.margins == (0, 2)
     consistency_asserts(screen)
 
     screen.resize(2, 2)
@@ -2218,7 +2220,7 @@ def test_alignment_display():
 def test_set_margins():
     screen = pyte.Screen(10, 10)
 
-    assert screen.margins is None
+    assert screen.margins == (0, 9)
 
     # a) ok-case
     screen.set_margins(1, 5)
@@ -2231,7 +2233,7 @@ def test_set_margins():
 
     # c) no margins provided -- reset to full screen.
     screen.set_margins()
-    assert screen.margins is None
+    assert screen.margins == (0, 9)
 
 
 def test_set_margins_zero():
@@ -2240,7 +2242,7 @@ def test_set_margins_zero():
     screen.set_margins(1, 5)
     assert screen.margins == (0, 4)
     screen.set_margins(0)
-    assert screen.margins is None
+    assert screen.margins == (0, 23)
 
 
 def test_hide_cursor():

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,10 +1,12 @@
-import io
+import io, sys, os
 
 import pytest
 
 import pyte
 from pyte import charsets as cs, control as ctrl, escape as esc
 
+sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
+from asserts import consistency_asserts
 
 class counter:
     def __init__(self):
@@ -227,6 +229,7 @@ def test_define_charset():
     stream = pyte.Stream(screen)
     stream.feed(ctrl.ESC + "(B")
     assert screen.display[0] == " " * 3
+    consistency_asserts(screen)
 
 
 def test_non_utf8_shifts():
@@ -305,6 +308,7 @@ def test_byte_stream_define_charset_unknown():
     stream.feed((ctrl.ESC + "(Z").encode())
     assert screen.display[0] == " " * 3
     assert screen.g0_charset == default_g0_charset
+    consistency_asserts(screen)
 
 
 @pytest.mark.parametrize("charset,mapping", cs.MAPS.items())
@@ -315,6 +319,7 @@ def test_byte_stream_define_charset(charset, mapping):
     stream.feed((ctrl.ESC + "(" + charset).encode())
     assert screen.display[0] == " " * 3
     assert screen.g0_charset == mapping
+    consistency_asserts(screen)
 
 
 def test_byte_stream_select_other_charset():


### PR DESCRIPTION
# What is this PR about?

Optimization. My goal was to make `pyte` faster and lighter specially
for large geometries (think in a screen of 240x800 or 2400x8000).


# Results (overview of the results)

For large geometries (240x800, 2400x8000), `Screen.display` runs several orders
of magnitude faster and consumes between 1.10 and 50.0 times less memory.

For smaller geometries the minimum improvement was of 2 times faster.

`Stream.feed` is now between 1.10 and 7.30 times faster and if
`Screen` is tuned, the speedup is between 1.14 and 12.0.

However there is a regression for the `mc.input` test of up to 4 times
slower.

For memory usage, `Stream.feed` is between 1.10 and 17.0 times lighter
and up to 44.0 times lighter if `Screen` is tuned.

Screen.reset is between 1.10 and 1.50 slower but several cases improve
if the `Screen` is tuned (but not all).

# Context (background)

[byexample](https://byexamples.github.io/byexample/) executes snippets
of code using real interpreters (Python, Ruby, Java) and capturing the
output so then `byexample` can check if it is the expected or not.

While most of the interpreters are *"terminal-naive"*, some are
*"terminal-aware"* and they will output escape and control sequences
which obviously are not of interest.

`byexample` uses `pyte` for handling those cases (thanks for such great
lib!!).

Unfortunately using a screen introduces artifacts due the hard
boundaries of the screen (24x80). Think in very long lines that are
"unexpectedly" cut into two lines (cut that happen because the screen
has a finite width).

A simple and elegant solution could create screen for larger geometries
where these artifacts are much more rare.

Sadly, while `pyte` implements a sparse buffer, most of its algorithms
are not aware and they don't take advantage of that making the terminal
emulation really slow and consuming a lot of memory.

This is the motivation for this PR: make it perform better!!

# Note for the reviewers

This PR is not trivial. The commits are simple of understand (as much as
I could) but still it is a quite large PR.

So I will be available for discussion and explanation of each commit so
I can guide the review process.

# Contributions

 - Upgrade pyperf
 - Extended the benchmark tests to test `Screen.display`,
`Screen.resize` and `Screen.reset` under different geometries (24x80,
240x800, 2400x8000, 24x8000, 2400x80). With these the benchmark takes
much more time (sorry!) but it gives a deeper view of how `pyte` works.
 - Fixed a bug in the benchmarks that used `Stream` instead of
`ByteStream`. The use of the former led to an incorrect interpretation
of the new lines; the use of `ByteStream` fixed that and it is aligned
with the `test_input_output.py` tests.
 - Optimize `Screen.display` to work (approx) linearly with the input
and not with the size of the screen (quadratic). Improved by a lot
both for runtime and memory (specially for large geometries).
 - Implement `Screen.compressed_display` that works similar to
`Screen.display` but it allows to *"strip"* empty space from the left or
right and *"filter"* empty lines on top and bottom of the screen
reducing time and memory.
 - Optimize `Screen.draw` with caching of attributes and methods (the
same optimizations already present in `Stream._parser_fsm`).
 - Refactor out `Char`'s foreground, bold, blink (...) into a separated
`namedtuple` `CharStyle`. When possible, reuse the same style for
multiple characters reducing the memory usage at the expense of an
additional lookup (instead of `char.fg` you have `char.style.fg`).
 - Make `Char` a mutable object allowing changes in the `data` and
`width` fields to be in-place instead of creating a new `Char` object.
 - Sparse-aware algorithms for `Screen.index` and `Screen.reverse_index`
which improved indirectly `Screen.draw` and `Stream.feed`.
 - Sparse-aware algorithms for `Screen.resize`
 - Sparse-aware algorithms for `Screen.tabstop`
 - Sparse-aware algorithms for `ScreenHistory.prev_page` and
`ScreenHistory.next_page`.
 - Sparse-aware algorithms for `Screen.insert_characters`,
`Screen.delete_characters`, `Screen.insert_lines` and
`Screen.delete_characters` which improved the performance of *"terminal
aware"* programs.
 - Statistics about `Screen`'s buffer and lines to have insight about
the sparsity and usage of these elements. (The API is not not standard
like `DebugScreen`).
 - Make the public attribute `Screen.buffer` return a `BufferView`.
Retrieve of lines from it yield `LineView` instead of `Line` objects.
This adds an overhead on user code but allows a separation between the
public part and the internals. Iterate over `LineView` still yields
`Char` objects as usual (to much high penalty otherwise).
 - Make the public `Screen.history`'s `top` and `bottom` queues return
`LineView` and not `Line` objects
 - Make the private attribute `Screen._buffer` a `dict` and not a
`defaultdict`. This prevent adding entries unintentionally which would
make the buffer less sparse and therefore slow.
 - If the current cursor attributes (style) matches the default
attributes of the screen, do not write explicit spaces on erase methods
(`Screen.erase_characters`, `Screen.erase_in_line` and
`Screen.erase_in_display`)
 - When `disable_display_graphic` is `True` prevent
`Screen.select_graphic_rendition` to change the cursor attributes
(style). If the cursor attrs don't change, we can optimize the erase
methods. The flag is `False` by default.
but just remove the chars from the buffer. This makes speedup other
algorithms and maintain high the sparsity (and consume less memory).
 - When `track_dirty_lines` is `False` use a `NullSet` for `Screen.dirty`
attribute to not consume any
memory and discard any element, disabling effectively the dirty
functionality. This saves time and memory for large geometries.
The flag is `True` by default.
 - Make `Screen.margin` always a `Margin` object so we can avoid
checking if it is `None` or not.
## Compatibility changes

The following are changes in the API that may break user code. A special
care was taken to avoid this situation.

 - `Char` is not longer a `namedtuple` so things like `_replace` are
gone. If necessary we could reimplement the API of `namedtuple` but I
don't think users will use.
 - `Char` is mutable but the user must not relay on this: changes to
character will have undefined behaviour. The user must use always the
API provided by `Screen`.
 - `Char` not longer has attributes for `fg`, `bg`, `bold`. Instead, it has a
single read-only `CharStyle`. The `Char` class implements  `fg`, `bg`, `bold`
as *properties* to do the lookup to the style behind the scene. User
code should not break then.
 - `Screen.buffer` now is a property that returns a `BufferView` with a
similar API to a dictionary. It yields `LineView` objects instead of
`Line` objects. These in turn yield `Char` objects (not views). User can
still iterate over the lines and chars as if the buffer were a dense
array and not a sparse array as it is really.
Like any view, these are valid until the next modification of the
screen. This change may break user code if it uses `buffer` in another
way.
 - The queues `top` and `bottom` of `ScreenHistory.history` contain
`LineView` and not `Line` objects. This may break user code.
 - `Screen.margin` is always a `Margin` object: the `None` value is not
longer supported`.

# TL;DR - Numbers overview

The following is a overview of the numbers got. To make this post
as short as possible, the some results were omitted
(rows omitted are marked with `:::`).

Full benchmark results are left attached. People is encouraged to do
their own benchmarks for cross validation.

### `Screen.display`

`Screen.display` was optimized to generate large chunks of spaces
very quickly.

For large geometries, this has an huge impact on the performance:

```
+----------------------------------------------------------+----------+-----------------------------------------+
| Benchmark                                                | 0.8.1    | 0.8.1+screen-optimizations+default-conf |
+==========================================================+==========+=========================================+
| [screen_display 2400x8000] mc.input->Screen              | 6.69 sec | 9.95 us: 672459.98x faster              |
| [screen_display 2400x8000] mc.input->HistoryScreen       | 6.60 sec | 10.3 us: 638209.07x faster              |
| [screen_display 2400x8000] vi.input->HistoryScreen       | 6.80 sec | 132 us: 51648.56x faster                |
| [screen_display 2400x8000] vi.input->Screen              | 6.60 sec | 130 us: 50691.68x faster                |
    :::                 ::::                                    ::::         :::
| [screen_display 240x800] ls.input->HistoryScreen         | 70.1 ms  | 248 us: 283.21x faster                  |
| [screen_display 240x800] ls.input->Screen                | 69.1 ms  | 244 us: 282.76x faster                  |
| [screen_display 240x800] top.input->Screen               | 68.2 ms  | 249 us: 273.98x faster                  |
| [screen_display 240x800] top.input->HistoryScreen        | 67.3 ms  | 257 us: 261.64x faster                  |
    :::                 ::::                                    ::::         :::
| [screen_display 24x80] find-etc.input->HistoryScreen     | 670 us   | 101 us: 6.63x faster                    |
| [screen_display 24x80] find-etc.input->Screen            | 640 us   | 97.9 us: 6.54x faster                   |
| [screen_display 24x80] vi.input->HistoryScreen           | 606 us   | 115 us: 5.27x faster                    |
| [screen_display 24x80] vi.input->Screen                  | 584 us   | 117 us: 5.00x faster                    |
| [screen_display 24x80] cat-gpl3.input->Screen            | 605 us   | 189 us: 3.21x faster                    |
| [screen_display 24x80] cat-gpl3.input->HistoryScreen     | 605 us   | 195 us: 3.11x faster                    |
| [screen_display 24x80] ls.input->HistoryScreen           | 609 us   | 221 us: 2.75x faster                    |
| [screen_display 24x80] ls.input->Screen                  | 585 us   | 221 us: 2.65x faster                    |
| [screen_display 24x80] top.input->Screen                 | 567 us   | 244 us: 2.33x faster                    |
| [screen_display 24x80] top.input->HistoryScreen          | 580 us   | 251 us: 2.32x faster                    |
| [screen_display 24x80] htop.input->HistoryScreen         | 564 us   | 269 us: 2.10x faster                    |
| [screen_display 24x80] htop.input->Screen                | 559 us   | 273 us: 2.05x faster                    |
```

`Screen.display` takes advantage of the sparsity of the screen and therefore
it was indirectly beneficed by the optimizations done across `Screen`
to avoid filling it with *false entries*.

`Screen.display` it was also optimized on memory (`tracemalloc`) avoiding
then append of each space character separately when they could be
appended in a single chunk.

```
+--------------------------------------------------------------+-------------------+-----------------------------------------------------+
| Benchmark                                                    | 0.8.1.tracemalloc | 0.8.1+screen-optimizations+default-conf.tracemalloc |
+==============================================================+===================+=====================================================+
| [screen_display 2400x8000] ls.input->HistoryScreen           | 19.7 MB           | 408.1 kB: 49.43x faster                             |
| [screen_display 2400x8000] mc.input->HistoryScreen           | 19.7 MB           | 411.4 kB: 49.04x faster                             |
| [screen_display 2400x8000] mc.input->Screen                  | 19.7 MB           | 411.4 kB: 49.04x faster                             |
| [screen_display 2400x8000] ls.input->Screen                  | 19.7 MB           | 411.5 kB: 49.03x faster                             |
| [screen_display 2400x8000] vi.input->HistoryScreen           | 18.5 MB           | 404.7 kB: 46.84x faster                             |
| [screen_display 2400x8000] top.input->HistoryScreen          | 18.5 MB           | 408.3 kB: 46.43x faster                             |
| [screen_display 2400x8000] vi.input->Screen                  | 18.5 MB           | 408.5 kB: 46.40x faster                             |
| [screen_display 2400x8000] top.input->Screen                 | 18.5 MB           | 411.5 kB: 46.07x faster                             |
| [screen_display 2400x8000] htop.input->Screen                | 18.5 MB           | 1102.6 kB: 17.19x faster                            |
| [screen_display 2400x8000] htop.input->HistoryScreen         | 18.5 MB           | 1103.2 kB: 17.18x faster                            |
| [screen_display 2400x8000] cat-gpl3.input->HistoryScreen     | 19.5 MB           | 5392.6 kB: 3.70x faster                             |
| [screen_display 2400x8000] cat-gpl3.input->Screen            | 19.5 MB           | 5392.0 kB: 3.70x faster                             |
| [screen_display 240x800] mc.input->Screen                    | 513.2 kB          | 403.5 kB: 1.27x faster                              |
| [screen_display 240x800] ls.input->Screen                    | 517.0 kB          | 411.5 kB: 1.26x faster                              |
| [screen_display 240x800] ls.input->HistoryScreen             | 511.7 kB          | 408.1 kB: 1.25x faster                              |
| [screen_display 240x800] mc.input->HistoryScreen             | 510.4 kB          | 411.4 kB: 1.24x faster                              |
| [screen_display 2400x8000] find-etc.input->HistoryScreen     | 18.7 MB           | 16.6 MB: 1.12x faster                               |
| [screen_display 2400x8000] find-etc.input->Screen            | 18.7 MB           | 16.6 MB: 1.12x faster                               |
```

The only two regressions are:

```
| [screen_display 240x800] htop.input->HistoryScreen           | 408.7 kB          | 487.3 kB: 1.19x slower                              |
| [screen_display 240x800] htop.input->Screen                  | 405.8 kB          | 486.2 kB: 1.20x slower                              |
```

Not sure why this happen.


### `Stream.feed`

`stream.feed` was not modified but its runtime depends on `Screen`'s
performance.

For terminal programs that just write into then terminal, like
`cat-gpl3` and `find-etc`, `stream.feed` merely sends then input
to `Screen.draw` for rendering.

The method `Screen.draw` was optimized to avoid the modification
of the cursor internally and update it only at the exit. This saved a
few lookups.

While not been frequently called, `Screen.index` was the next bottleneck
for `Screen.draw`: it moves all the lines of the screen which it means
that all the entries of the buffer are rewritten.

`Screen.index` and `Screen.reverse_index` were optimized to take advantage
of the sparsity and to avoid adding false entries.

This resulted on a speedup across the tests:
```
+----------------------------------------------------------+----------+-----------------------------------------+
| Benchmark                                                | 0.8.1    | 0.8.1+screen-optimizations+default-conf |
+==========================================================+==========+=========================================+
| [stream_feed 2400x8000] vi.input->HistoryScreen          | 49.4 ms  | 6.70 ms: 7.38x faster                   |
| [stream_feed 2400x8000] top.input->HistoryScreen         | 7.35 ms  | 1.31 ms: 5.62x faster                   |
| [stream_feed 2400x8000] find-etc.input->HistoryScreen    | 2.92 sec | 543 ms: 5.38x faster                    |
| [stream_feed 240x800] ls.input->HistoryScreen            | 9.29 ms  | 1.75 ms: 5.31x faster                   |
| [stream_feed 24x80] top.input->HistoryScreen             | 6.61 ms  | 1.25 ms: 5.30x faster                   |
| [stream_feed 240x800] top.input->HistoryScreen           | 6.57 ms  | 1.24 ms: 5.29x faster                   |
| [stream_feed 240x800] cat-gpl3.input->HistoryScreen      | 215 ms   | 43.3 ms: 4.97x faster                   |
| [stream_feed 24x80] ls.input->HistoryScreen              | 6.26 ms  | 1.34 ms: 4.68x faster                   |
| [stream_feed 24x80] cat-gpl3.input->HistoryScreen        | 140 ms   | 31.9 ms: 4.38x faster                   |
| [stream_feed 240x800] find-etc.input->HistoryScreen      | 532 ms   | 123 ms: 4.32x faster                    |
| [stream_feed 2400x8000] vi.input->Screen                 | 13.7 ms  | 3.53 ms: 3.88x faster                   |
| [stream_feed 24x80] find-etc.input->HistoryScreen        | 294 ms   | 81.1 ms: 3.62x faster                   |
| [stream_feed 2400x8000] htop.input->HistoryScreen        | 122 ms   | 34.4 ms: 3.54x faster                   |
    :::                 ::::                                    ::::         :::
| [stream_feed 240x800] vi.input->Screen                   | 5.39 ms  | 2.67 ms: 2.02x faster                   |
| [stream_feed 24x80] mc.input->HistoryScreen              | 44.3 ms  | 24.4 ms: 1.82x faster                   |
| [stream_feed 2400x8000] htop.input->Screen               | 38.1 ms  | 21.4 ms: 1.78x faster                   |
| [stream_feed 240x800] htop.input->Screen                 | 23.2 ms  | 13.2 ms: 1.76x faster                   |
| [stream_feed 240x800] find-etc.input->Screen             | 134 ms   | 77.0 ms: 1.74x faster                   |
| [stream_feed 24x80] vi.input->Screen                     | 4.45 ms  | 2.57 ms: 1.73x faster                   |
| [stream_feed 24x80] htop.input->Screen                   | 20.8 ms  | 12.2 ms: 1.71x faster                   |
| [stream_feed 2400x8000] cat-gpl3.input->HistoryScreen    | 262 ms   | 157 ms: 1.67x faster                    |
| [stream_feed 240x800] mc.input->HistoryScreen            | 63.7 ms  | 43.8 ms: 1.45x faster                   |
| [stream_feed 2400x8000] ls.input->Screen                 | 7.77 ms  | 5.61 ms: 1.38x faster                   |
| [stream_feed 24x80] mc.input->Screen                     | 17.6 ms  | 13.1 ms: 1.34x faster                   |
| [stream_feed 2400x8000] find-etc.input->Screen           | 616 ms   | 501 ms: 1.23x faster                    |
| [stream_feed 2400x8000] cat-gpl3.input->Screen           | 170 ms   | 143 ms: 1.19x faster                    |
| [stream_feed 2400x8000] mc.input->HistoryScreen          | 259 ms   | 285 ms: 1.10x slower                    |
| [stream_feed 240x800] mc.input->Screen                   | 23.3 ms  | 32.3 ms: 1.39x slower                   |
| [stream_feed 2400x8000] mc.input->Screen                 | 71.2 ms  | 281 ms: 3.94x slower                    |
```

The `mc.input` however took much more time.
When `track_dirty_lines` is `False` and `disable_display_graphic` is `True`,
the overall performance increases even further.

```
+----------------------------------------------------------+----------+----------------------------------------+
| Benchmark                                                | 0.8.1    | 0.8.1+screen-optimizations+custom-conf |
+==========================================================+==========+========================================+
| [stream_feed 2400x8000] mc.input->HistoryScreen          | 259 ms   | 21.2 ms: 12.19x faster                 |
| [stream_feed 2400x8000] vi.input->HistoryScreen          | 49.4 ms  | 5.52 ms: 8.95x faster                  |
| [stream_feed 2400x8000] mc.input->Screen                 | 71.2 ms  | 10.8 ms: 6.60x faster                  |
| [stream_feed 2400x8000] find-etc.input->HistoryScreen    | 2.92 sec | 464 ms: 6.29x faster                   |
| [stream_feed 2400x8000] top.input->HistoryScreen         | 7.35 ms  | 1.27 ms: 5.80x faster                  |
| [stream_feed 2400x8000] htop.input->HistoryScreen        | 122 ms   | 22.3 ms: 5.45x faster                  |
| [stream_feed 2400x8000] vi.input->Screen                 | 13.7 ms  | 2.52 ms: 5.43x faster                  |
| [stream_feed 24x80] top.input->HistoryScreen             | 6.61 ms  | 1.23 ms: 5.38x faster                  |
| [stream_feed 240x800] ls.input->HistoryScreen            | 9.29 ms  | 1.73 ms: 5.37x faster                  |
| [stream_feed 240x800] cat-gpl3.input->HistoryScreen      | 215 ms   | 42.0 ms: 5.12x faster                  |
    :::                 ::::                                    ::::         :::
| [stream_feed 24x80] cat-gpl3.input->Screen               | 46.3 ms  | 17.2 ms: 2.69x faster                  |
| [stream_feed 240x800] top.input->Screen                  | 2.39 ms  | 913 us: 2.61x faster                   |
| [stream_feed 24x80] top.input->Screen                    | 2.36 ms  | 914 us: 2.58x faster                   |
| [stream_feed 2400x8000] ls.input->HistoryScreen          | 13.4 ms  | 5.39 ms: 2.50x faster                  |
| [stream_feed 24x80] htop.input->HistoryScreen            | 55.3 ms  | 22.6 ms: 2.44x faster                  |
    :::                 ::::                                    ::::         :::
| [stream_feed 240x800] vi.input->Screen                   | 5.39 ms  | 2.57 ms: 2.10x faster                  |
| [stream_feed 24x80] mc.input->HistoryScreen              | 44.3 ms  | 21.3 ms: 2.08x faster                  |
| [stream_feed 2400x8000] cat-gpl3.input->HistoryScreen    | 262 ms   | 132 ms: 1.99x faster                   |
| [stream_feed 240x800] find-etc.input->Screen             | 134 ms   | 76.3 ms: 1.76x faster                  |
| [stream_feed 24x80] vi.input->Screen                     | 4.45 ms  | 2.54 ms: 1.75x faster                  |
| [stream_feed 24x80] mc.input->Screen                     | 17.6 ms  | 10.6 ms: 1.66x faster                  |
| [stream_feed 2400x8000] ls.input->Screen                 | 7.77 ms  | 4.85 ms: 1.60x faster                  |
| [stream_feed 2400x8000] find-etc.input->Screen           | 616 ms   | 422 ms: 1.46x faster                   |
| [stream_feed 2400x8000] cat-gpl3.input->Screen           | 170 ms   | 118 ms: 1.44x faster                   |
```


On memory there is an improvement too:
```
+--------------------------------------------------------------+-------------------+-----------------------------------------------------+
| Benchmark                                                    | 0.8.1.tracemalloc | 0.8.1+screen-optimizations+default-conf.tracemalloc |
+==============================================================+===================+=====================================================+
| [stream_feed 2400x8000] vi.input->HistoryScreen              | 11.7 MB           | 686.8 kB: 17.45x faster                             |
| [stream_feed 2400x8000] vi.input->Screen                     | 4742.1 kB         | 538.0 kB: 8.81x faster                              |
| [stream_feed 2400x8000] htop.input->HistoryScreen            | 14.5 MB           | 3552.1 kB: 4.18x faster                             |
| [stream_feed 240x800] vi.input->HistoryScreen                | 2679.0 kB         | 686.8 kB: 3.90x faster                              |
| [stream_feed 2400x8000] top.input->HistoryScreen             | 2120.7 kB         | 611.8 kB: 3.47x faster                              |
| [stream_feed 2400x8000] htop.input->Screen                   | 11.5 MB           | 3408.2 kB: 3.45x faster                             |
| [stream_feed 2400x8000] top.input->Screen                    | 2155.1 kB         | 680.2 kB: 3.17x faster                              |
| [stream_feed 240x800] htop.input->HistoryScreen              | 2189.7 kB         | 1005.8 kB: 2.18x faster                             |
| [stream_feed 240x800] vi.input->Screen                       | 1107.7 kB         | 536.1 kB: 2.07x faster                              |
| [stream_feed 240x800] htop.input->Screen                     | 1782.7 kB         | 990.6 kB: 1.80x faster                              |
            :::                 ::::                                    ::::         :::
| [stream_feed 240x800] find-etc.input->HistoryScreen          | 2233.5 kB         | 1502.4 kB: 1.49x faster                             |
| [stream_feed 24x80] ls.input->HistoryScreen                  | 1554.3 kB         | 1086.0 kB: 1.43x faster                             |
| [stream_feed 24x80] cat-gpl3.input->HistoryScreen            | 1354.0 kB         | 960.1 kB: 1.41x faster                              |
| [stream_feed 24x80] top.input->Screen                        | 948.2 kB          | 680.2 kB: 1.39x faster                              |
| [stream_feed 24x80] vi.input->HistoryScreen                  | 954.7 kB          | 686.8 kB: 1.39x faster                              |
| [stream_feed 24x80] find-etc.input->HistoryScreen            | 1017.6 kB         | 774.9 kB: 1.31x faster                              |
| [stream_feed 240x800] top.input->HistoryScreen               | 763.6 kB          | 653.6 kB: 1.17x faster                              |
| [stream_feed 24x80] mc.input->HistoryScreen                  | 485.0 kB          | 417.6 kB: 1.16x faster                              |
| [stream_feed 24x80] htop.input->Screen                       | 936.1 kB          | 814.3 kB: 1.15x faster                              |
| [stream_feed 24x80] mc.input->Screen                         | 722.3 kB          | 651.6 kB: 1.11x faster                              |
```


The following are the tests that show regression on memory usage.

```
| [stream_feed 240x800] mc.input->Screen                       | 1842.2 kB         | 2577.4 kB: 1.40x slower                             |
| [stream_feed 240x800] mc.input->HistoryScreen                | 1793.2 kB         | 2548.1 kB: 1.42x slower                             |
| [stream_feed 2400x8000] mc.input->HistoryScreen              | 13.6 MB           | 22.3 MB: 1.64x slower                               |
| [stream_feed 2400x8000] ls.input->HistoryScreen              | 8422.1 kB         | 13.7 MB: 1.67x slower                               |
| [stream_feed 2400x8000] mc.input->Screen                     | 12.2 MB           | 22.3 MB: 1.82x slower                               |
```
When `track_dirty_lines` is `False` and `disable_display_graphic` is `True`, this is even better:

```
+--------------------------------------------------------------+-------------------+----------------------------------------------------+
| Benchmark                                                    | 0.8.1.tracemalloc | 0.8.1+screen-optimizations+custom-conf.tracemalloc |
+==============================================================+===================+====================================================+
| [stream_feed 2400x8000] mc.input->HistoryScreen              | 13.6 MB           | 414.1 kB: 33.60x faster                            |
| [stream_feed 2400x8000] mc.input->Screen                     | 12.2 MB           | 447.6 kB: 27.98x faster                            |
| [stream_feed 2400x8000] htop.input->Screen                   | 11.5 MB           | 600.5 kB: 19.59x faster                            |
| [stream_feed 2400x8000] vi.input->HistoryScreen              | 11.7 MB           | 665.4 kB: 18.01x faster                            |
| [stream_feed 2400x8000] htop.input->HistoryScreen            | 14.5 MB           | 1009.0 kB: 14.73x faster                           |
| [stream_feed 2400x8000] vi.input->Screen                     | 4742.1 kB         | 522.4 kB: 9.08x faster                             |
| [stream_feed 240x800] mc.input->HistoryScreen                | 1793.2 kB         | 417.4 kB: 4.30x faster                             |
| [stream_feed 240x800] mc.input->Screen                       | 1842.2 kB         | 447.6 kB: 4.12x faster                             |
| [stream_feed 240x800] vi.input->HistoryScreen                | 2679.0 kB         | 652.6 kB: 4.11x faster                             |
| [stream_feed 2400x8000] top.input->HistoryScreen             | 2120.7 kB         | 653.6 kB: 3.24x faster                             |
| [stream_feed 2400x8000] top.input->Screen                    | 2155.1 kB         | 680.6 kB: 3.17x faster                             |
| [stream_feed 240x800] htop.input->Screen                     | 1782.7 kB         | 600.5 kB: 2.97x faster                             |
| [stream_feed 240x800] htop.input->HistoryScreen              | 2189.7 kB         | 785.0 kB: 2.79x faster                             |
| [stream_feed 240x800] vi.input->Screen                       | 1107.7 kB         | 522.4 kB: 2.12x faster                             |
| [stream_feed 2400x8000] cat-gpl3.input->HistoryScreen        | 20.3 MB           | 11.8 MB: 1.72x faster                              |
            :::                 ::::                                    ::::         :::
| [stream_feed 24x80] find-etc.input->HistoryScreen            | 1017.6 kB         | 774.8 kB: 1.31x faster                             |
| [stream_feed 240x800] top.input->HistoryScreen               | 763.6 kB          | 653.6 kB: 1.17x faster                             |
| [stream_feed 24x80] mc.input->HistoryScreen                  | 485.0 kB          | 422.0 kB: 1.15x faster                             |
```

However, we still have some regressions:

```
| [stream_feed 24x80] htop.input->HistoryScreen                | 863.7 kB          | 1009.0 kB: 1.17x slower                            |
| [stream_feed 2400x8000] ls.input->HistoryScreen              | 8422.1 kB         | 13.7 MB: 1.67x slower                              |
```

### `Screen.reset`

For `Screen.reset` we have a regressions, some minor, some not-so-much
minor:

```
+----------------------------------------------------------+----------+-----------------------------------------+
| Benchmark                                                | 0.8.1    | 0.8.1+screen-optimizations+default-conf |
+==========================================================+==========+=========================================+
| [screen_reset 2400x8000] ls.input->HistoryScreen         | 65.4 us  | 68.9 us: 1.05x slower                   |
| [screen_reset 2400x8000] mc.input->Screen                | 51.9 us  | 54.8 us: 1.06x slower                   |
| [screen_reset 2400x8000] top.input->HistoryScreen        | 65.6 us  | 69.5 us: 1.06x slower                   |
    :::                 ::::                                    ::::         :::
| [screen_reset 24x80] cat-gpl3.input->HistoryScreen       | 13.2 us  | 15.4 us: 1.17x slower                   |
| [screen_reset 24x80] vi.input->HistoryScreen             | 13.0 us  | 15.3 us: 1.18x slower                   |
| [screen_reset 240x800] htop.input->Screen                | 4.87 us  | 5.78 us: 1.19x slower                   |
| [screen_reset 24x80] mc.input->HistoryScreen             | 13.1 us  | 15.7 us: 1.19x slower                   |
| [screen_reset 240x800] mc.input->Screen                  | 4.81 us  | 5.75 us: 1.20x slower                   |
| [screen_reset 24x80] ls.input->HistoryScreen             | 13.0 us  | 15.5 us: 1.20x slower                   |
| [screen_reset 24x80] find-etc.input->HistoryScreen       | 13.0 us  | 15.6 us: 1.20x slower                   |
| [screen_reset 24x80] htop.input->HistoryScreen           | 12.9 us  | 15.5 us: 1.21x slower                   |
| [screen_reset 240x800] find-etc.input->Screen            | 4.86 us  | 5.87 us: 1.21x slower                   |
| [screen_reset 240x800] htop.input->HistoryScreen         | 15.6 us  | 18.9 us: 1.21x slower                   |
| [screen_reset 240x800] vi.input->Screen                  | 4.83 us  | 5.87 us: 1.22x slower                   |
| [screen_reset 240x800] top.input->Screen                 | 4.72 us  | 5.77 us: 1.22x slower                   |
    :::                 ::::                                    ::::         :::
| [screen_reset 240x800] ls.input->Screen                  | 4.79 us  | 5.86 us: 1.22x slower                   |
| [screen_reset 240x800] cat-gpl3.input->Screen            | 4.79 us  | 5.89 us: 1.23x slower                   |
| [screen_reset 24x80] vi.input->Screen                    | 2.05 us  | 3.05 us: 1.49x slower                   |
| [screen_reset 24x80] mc.input->Screen                    | 2.04 us  | 3.05 us: 1.49x slower                   |
| [screen_reset 24x80] ls.input->Screen                    | 2.01 us  | 3.01 us: 1.50x slower                   |
| [screen_reset 24x80] htop.input->Screen                  | 2.02 us  | 3.06 us: 1.51x slower                   |
| [screen_reset 24x80] cat-gpl3.input->Screen              | 2.03 us  | 3.07 us: 1.52x slower                   |
| [screen_reset 24x80] top.input->Screen                   | 2.03 us  | 3.11 us: 1.53x slower                   |
| [screen_reset 24x80] find-etc.input->Screen              | 2.00 us  | 3.06 us: 1.53x slower                   |
```

However when
`track_dirty_lines` is `False` and `disable_display_graphic` is `True`,
the things improves (but we still have regressions):

```
+----------------------------------------------------------+----------+----------------------------------------+
| Benchmark                                                | 0.8.1    | 0.8.1+screen-optimizations+custom-conf |
+==========================================================+==========+========================================+
| [screen_reset 2400x8000] find-etc.input->Screen          | 51.3 us  | 15.2 us: 3.38x faster                  |
| [screen_reset 2400x8000] mc.input->Screen                | 51.9 us  | 15.5 us: 3.35x faster                  |
| [screen_reset 2400x8000] vi.input->Screen                | 52.8 us  | 15.9 us: 3.32x faster                  |
    :::                 ::::                                    ::::         :::
| [screen_reset 2400x8000] cat-gpl3.input->HistoryScreen   | 66.5 us  | 29.9 us: 2.22x faster                  |
| [screen_reset 2400x8000] htop.input->HistoryScreen       | 64.6 us  | 29.4 us: 2.20x faster                  |
| [screen_reset 240x800] htop.input->Screen                | 4.87 us  | 4.58 us: 1.06x faster                  |
| [screen_reset 240x800] find-etc.input->Screen            | 4.86 us  | 4.62 us: 1.05x faster                  |
| [screen_reset 240x800] cat-gpl3.input->HistoryScreen     | 16.0 us  | 17.0 us: 1.06x slower                  |
| [screen_reset 240x800] mc.input->HistoryScreen           | 16.0 us  | 17.1 us: 1.07x slower                  |
| [screen_reset 240x800] find-etc.input->HistoryScreen     | 16.1 us  | 17.3 us: 1.07x slower                  |
| [screen_reset 240x800] top.input->HistoryScreen          | 15.9 us  | 17.1 us: 1.08x slower                  |
| [screen_reset 240x800] htop.input->HistoryScreen         | 15.6 us  | 17.5 us: 1.12x slower                  |
    :::                 ::::                                    ::::         :::
| [screen_reset 24x80] htop.input->HistoryScreen           | 12.9 us  | 15.3 us: 1.19x slower                  |
| [screen_reset 24x80] htop.input->Screen                  | 2.02 us  | 2.89 us: 1.43x slower                  |
| [screen_reset 24x80] top.input->Screen                   | 2.03 us  | 2.92 us: 1.44x slower                  |
| [screen_reset 24x80] mc.input->Screen                    | 2.04 us  | 2.94 us: 1.44x slower                  |
| [screen_reset 24x80] ls.input->Screen                    | 2.01 us  | 2.90 us: 1.44x slower                  |
| [screen_reset 24x80] vi.input->Screen                    | 2.05 us  | 2.96 us: 1.44x slower                  |
| [screen_reset 24x80] find-etc.input->Screen              | 2.00 us  | 2.90 us: 1.45x slower                  |
| [screen_reset 24x80] cat-gpl3.input->Screen              | 2.03 us  | 2.96 us: 1.46x slower                  |
```

