### PR TITLE
Understand (and discard) SGR subparameters

### DIFF
--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -319,7 +319,7 @@ class Stream:
                 #        For details on the characters valid for use as
                 #        arguments.
                 params = []
-                current = ""
+                current = 0
                 private = False
                 while True:
                     char = yield None
@@ -337,17 +337,18 @@ class Stream:
                         draw(char)
                         break
                     elif char.isdigit():
-                        current += char
+                        digit_value = ord(char) - ord("0")
+                        current = min(current * 10 + digit_value, 9999)
                     elif char == "$":
                         # XTerm-specific ESC]...$[a-z] sequences are not
                         # currently supported.
                         yield None
                         break
                     else:
-                        params.append(min(int(current or 0), 9999))
+                        params.append(current)
 
                         if char == ";":
-                            current = ""
+                            current = 0
                         else:
                             if private:
                                 csi_dispatch[char](*params, private=True)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -70,6 +70,19 @@ def test_unknown_sequences():
     assert handler.args == (6, 0)
     assert handler.kwargs == {}
 
+def test_csi_param_with_colon_context():
+    handler = argcheck()
+    screen = pyte.Screen(80, 24)
+    screen.debug = handler
+
+    stream = pyte.Stream(screen)
+    stream.feed(ctrl.CSI + "6:4Z")
+    assert handler.count == 1
+    # Note: currently pyte doesn't actually do anything with `:`-delimited context,
+    # which is why the `4` disappears here.
+    assert handler.args == ((6),)
+    assert handler.kwargs == {}
+
 
 def test_non_csi_sequences():
     for cmd, event in pyte.Stream.csi.items():


### PR DESCRIPTION
This completes https://github.com/selectel/pyte/issues/178. pyte now understands `:`-delimited subparameters, but doesn't actually do anything with them (which is better than the previous behavior, where they'd get spewed to the screen buffer.

I've split the work here into 2 separate commits, each with some explanation in the commit message, I recommend reading them independently.

I've also laid the groundwork for actually *using* these subparameters, which I'm tracking in <https://github.com/selectel/pyte/issues/179>