### PR TITLE
Implement setting custom colours by number

### DIFF
--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -544,6 +544,19 @@ class Screen:
         """
         self.icon_name = param
 
+    def set_color_number(self, index: int, color: str) -> None:
+        """Set colour number index to be the specified colour (in hex)
+        """
+        # TODO: This has no way to reset colors back to their original.
+        if index > 15:
+            g.FG_BG_256[index] = color
+        elif index > 7:  # Bright colors
+            g.FG_AIXTERM[index + 82] = color
+            g.BG_AIXTERM[index + 92] = color
+        else:
+            g.FG_ANSI[index + 30] = color
+            g.BG_ANSI[index + 40] = color
+
     def carriage_return(self) -> None:
         """Move the cursor to the beginning of the current line."""
         self.cursor.x = 0

--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -376,6 +376,9 @@ class Stream:
                     listener.set_icon_name(param)
                 if code in "02":
                     listener.set_title(param)
+                if code == "4":
+                    index, color = param.split(";")
+                    listener.set_color_number(int(index), color[4:].replace("/", "").lower())
             elif char not in NUL_OR_DEL:
                 draw(char)
 


### PR DESCRIPTION
This is obviously not an ideal solution, but it's better than no support. If you can help advise how you'd prefer to store custom palettes (should they be stored in the char tuple, so that display can query it? Or where would you like the "override" stored?) I can fix it.

See #50