### PR TITLE
Fix some typing related imports

### DIFF
--- a/pyte/__init__.py
+++ b/pyte/__init__.py
@@ -26,8 +26,6 @@ __all__ = ("Screen", "DiffScreen", "HistoryScreen", "DebugScreen",
            "Stream", "ByteStream")
 
 import io
-from typing import Union
-
 from .screens import Screen, DiffScreen, HistoryScreen, DebugScreen
 from .streams import Stream, ByteStream
 

--- a/pyte/__init__.py
+++ b/pyte/__init__.py
@@ -25,12 +25,13 @@
 __all__ = ("Screen", "DiffScreen", "HistoryScreen", "DebugScreen",
            "Stream", "ByteStream")
 
-import io
 from .screens import Screen, DiffScreen, HistoryScreen, DebugScreen
 from .streams import Stream, ByteStream
 
 
 if __debug__:
+    import io
+
     def dis(chars: bytes | str) -> None:
         """A :func:`dis.dis` for terminals.
 

--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -35,8 +35,7 @@ import unicodedata
 import warnings
 from collections import deque, defaultdict
 from functools import lru_cache
-from typing import Any, Dict, List, NamedTuple, Optional, Set, TextIO, TypeVar
-from collections.abc import Callable, Generator, Sequence
+from typing import TYPE_CHECKING, NamedTuple, TypeVar
 
 from wcwidth import wcwidth as _wcwidth  # type: ignore[import-untyped]
 
@@ -47,6 +46,10 @@ from . import (
     modes as mo
 )
 from .streams import Stream
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Sequence
+    from typing import Any, NamedTuple, TextIO
 
 wcwidth: Callable[[str], int] = lru_cache(maxsize=4096)(_wcwidth)
 

--- a/pyte/streams.py
+++ b/pyte/streams.py
@@ -25,17 +25,17 @@ import itertools
 import re
 import warnings
 from collections import defaultdict
-from collections.abc import Mapping
-from typing import Any, Dict, Optional, TYPE_CHECKING
-from collections.abc import Callable, Generator
+from typing import TYPE_CHECKING
 
 from . import control as ctrl, escape as esc
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Generator, Mapping
+    from typing import Any
     from .screens import Screen
 
+    ParserGenerator = Generator[bool | None, str, None]
 
-ParserGenerator = Generator[Optional[bool], str, None]
 
 class Stream:
     """A stream is a state machine that parses a stream of bytes and


### PR DESCRIPTION
This PR...

1. removes obsolete type imports such as `Dict`, `Optional`, ... .
2. imports as many types as possible in TYPE_CHECKING mode, only to limit
   impact of typing on runtime import time.