### PR TITLE
Fix TypeError in select_graphic_rendition

### DIFF
--- a/pyte/screens.py
+++ b/pyte/screens.py
@@ -971,11 +971,15 @@ class Screen:
             for x in range(self.columns):
                 self.buffer[y][x] = self.buffer[y][x]._replace(data="E")
 
-    def select_graphic_rendition(self, *attrs: int) -> None:
+    def select_graphic_rendition(self, *attrs: int, private: bool = False) -> None:
         """Set display attributes.
 
         :param list attrs: a list of display attributes to set.
+        :param bool private: if True, ignore the SGR sequence (private sequences are not supported).
         """
+        if private:
+            return
+
         replace = {}
 
         # Fast path for resetting all attributes.

--- a/tests/test_screen.py
+++ b/tests/test_screen.py
@@ -1583,3 +1583,24 @@ def test_screen_set_icon_name_title():
 
     screen.set_title(text)
     assert screen.title == text
+
+
+def test_private_sgr_sequence_ignored():
+    def cursor_state(cursor):
+        return (cursor.x, cursor.y, cursor.attrs, cursor.hidden)
+
+    screen = pyte.HistoryScreen(2, 2)
+    stream = pyte.ByteStream(screen)
+
+    # Capture initial state
+    display = screen.display
+    mode = screen.mode.copy()
+    cursor = cursor_state(screen.cursor)
+
+    # Vim 9.0+ sends this to query modifyOtherKeys capability - should be ignored
+    stream.feed(b'\x1b[?4m')
+
+    # Verify nothing changed
+    assert screen.display == display
+    assert screen.mode == mode
+    assert cursor_state(screen.cursor) == cursor


### PR DESCRIPTION
Fixes #202

- Add `private` parameter to select_graphic_rendition() method signature
- Handle `private=True` parameter by returning early (no-op for private SGR sequences)